### PR TITLE
Add typescricptFunctionCall

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -66,8 +66,11 @@ runtime syntax/basic/literal.vim
 syntax match typescriptOptionalMark /?/ contained
 syntax match typescriptRestOrSpread /\.\.\./ contained
 
-syntax match   typescriptIdentifierName        /\<[^=<>!?+\-*\/%|&,;:. ~@#`"'\[\]\(\)\{\}\^0-9][^=<>!?+\-*\/%|&,;:. ~@#`"'\[\]\(\)\{\}\^]*/ nextgroup=typescriptDotNotation,typescriptArgumentList,typescriptComputedProperty contains=@_semantic skipnl skipwhite
-syntax region   typescriptIdentifierName        start=/\<[^=<>!?+\-*\/%|&,;:. ~@#`"'\[\]\(\)\{\}\^0-9][^=<>!?+\-*\/%|&,;:. ~@#`"'\[\]\(\)\{\}\^]*</ end=/>\ze(/ nextgroup=typescriptDotNotation,typescriptArgumentList,typescriptComputedProperty contains=@_semantic,typescriptTypeArguments oneline skipnl skipwhite
+" Taken from https://github.com/pangloss/vim-javascript/blob/9f3ecf4595fb8a9b0b34e862001daccbbf61d17c/syntax/javascript.vim#L28
+syntax match   typescriptFunctionCall       /\k\+\%(\s*(\)\@=/
+
+syntax match   typescriptIdentifierName        /\<[^=<>!?+\-*\/%|&,;:. ~@#`"'\[\]\(\)\{\}\^0-9][^=<>!?+\-*\/%|&,;:. ~@#`"'\[\]\(\)\{\}\^]*/ nextgroup=typescriptDotNotation,typescriptArgumentList,typescriptComputedProperty contains=@_semantic,typescriptFunctionCall skipnl skipwhite
+syntax region   typescriptIdentifierName        start=/\<[^=<>!?+\-*\/%|&,;:. ~@#`"'\[\]\(\)\{\}\^0-9][^=<>!?+\-*\/%|&,;:. ~@#`"'\[\]\(\)\{\}\^]*</ end=/>\ze(/ nextgroup=typescriptDotNotation,typescriptArgumentList,typescriptComputedProperty contains=@_semantic,typescriptTypeArguments,typescriptFunctionCall oneline skipnl skipwhite
 
 "Block VariableStatement EmptyStatement ExpressionStatement IfStatement IterationStatement ContinueStatement BreakStatement ReturnStatement WithStatement LabelledStatement SwitchStatement ThrowStatement TryStatement DebuggerStatement
 


### PR DESCRIPTION
Relates to #12. Add `typescriptFunctionCall` to differentiate between typescript `fn` (a variable name) and `fn()` the invocation of that variable name. 

Maybe this image after I've applied the change will make it clear:
 
<img width="524" alt="screen_shot_2017-01-17_at_12_53_24_pm" src="https://cloud.githubusercontent.com/assets/3154865/22039437/24be11ba-dcb4-11e6-8154-0ea14ba70cf4.png">

### Feedback Welcome

I don't have much experience with using vim syntax `match` or `region` so if there is a better way to accomplish what I was going for please let me know.