### PR TITLE
make = sign highlight in member declaration

### DIFF
--- a/syntax/basic/class.vim
+++ b/syntax/basic/class.vim
@@ -53,6 +53,7 @@ syntax match typescriptMemberVariableDeclaration /[A-Za-z_$]\k*\s*:.*\($\|;\)/
   \ contained
 
 syntax match typescriptMemberVariableDeclaration /[A-Za-z_$]\k*\s*=/
+  \ contains=typescriptOpSymbols
   \ nextgroup=@typescriptExpression
   \ contained skipwhite skipnl
 

--- a/syntax/basic/class.vim
+++ b/syntax/basic/class.vim
@@ -46,10 +46,11 @@ syntax keyword typescriptClassStatic static nextgroup=
 syntax cluster typescriptPropertyMemberDeclaration contains=
   \ typescriptClassStatic,
   \ typescriptAccessibilityModifier,
-  \ typescriptMemberVariableDeclaration
+  \ typescriptMemberVariableDeclaration,
+  \ typescriptEndColons
 
 syntax match typescriptMemberVariableDeclaration /[A-Za-z_$]\k*\s*:.*\($\|;\)/
-  \ contains=typescriptTypeAnnotation
+  \ contains=typescriptTypeAnnotation,typescriptEndColons
   \ contained
 
 syntax match typescriptMemberVariableDeclaration /[A-Za-z_$]\k*\s*=/

--- a/syntax/basic/type.vim
+++ b/syntax/basic/type.vim
@@ -58,7 +58,7 @@ syntax match typescriptTypeReference /[A-Za-z_$]\w*\(\.[A-Za-z_$]\w*\)*/
 
 syntax region typescriptObjectType matchgroup=typescriptBraces
   \ start=/{/ end=/}/
-  \ contains=@typescriptTypeMember,@typescriptComments
+  \ contains=@typescriptTypeMember,@typescriptComments,typescriptEndColons
   \ nextgroup=typescriptUnionOrArrayType
   \ contained skipwhite fold
 


### PR DESCRIPTION
<img width="490" alt="screenshot 2017-01-26 18 34 11" src="https://cloud.githubusercontent.com/assets/11585206/22343514/9eb53fe8-e3f8-11e6-8cb0-303631c0c4ae.png">

As you can see a colorscheme which tries to highlight operator symbols, but fails at the first
equals sign inside the member variable declaration.
As shown in the next screenshot, that now works, but i still don't know how to make 
the ending colon on that line also highlight as the others do...

<img width="450" alt="screenshot 2017-01-26 18 34 48" src="https://cloud.githubusercontent.com/assets/11585206/22343638/28da3c82-e3f9-11e6-9562-cd552a6686fd.png">
