### PR TITLE
fix syntax matcher of typescriptAmbientModuleDeclaration

### DIFF
--- a/syntax/basic/ambient.vim
+++ b/syntax/basic/ambient.vim
@@ -60,7 +60,7 @@ syntax region typescriptAmbientPropertyMemberDeclaration matchgroup=typescriptAm
 syntax match   typescriptAmbientName /\k\+/ contained
 syntax keyword typescriptAmbientCtor constructor contained
 
-syntax region typescriptAmbientModuleDeclaration matchgroup=typescriptExport start=/module\>/ end=/\ze{/
+syntax region typescriptAmbientModuleDeclaration matchgroup=typescriptExport start=/module\>/ end=/\zs{/
   \ contains=typescriptString
   \ nextgroup=typescriptAmbientModuleBlock
   \ contained


### PR DESCRIPTION
I found a strange syntax highlight of my .d.ts.

![2017-02-18 2 46 19](https://cloud.githubusercontent.com/assets/11359892/23091167/accfac7c-f5ea-11e6-910e-a7ee6b7af7a8.png)

I made a fix according to this page.
\*:syn-multi-line\*
http://vimdoc.sourceforge.net/htmldoc/syntax.html#:syn-pattern

![2017-02-18 2 47 06](https://cloud.githubusercontent.com/assets/11359892/23091180/d72b6aa6-f5ea-11e6-85ef-5aab00583321.png)
