### PR TITLE
Fix TSX attributes indention

### DIFF
--- a/indent/typescriptreact.vim
+++ b/indent/typescriptreact.vim
@@ -22,7 +22,6 @@ setlocal indentkeys+=*<Return>,<>>,<<>,/
 " Multiline end tag regex (line beginning with '>' or '/>')
 let s:endtag = '^\s*\/\?>\s*;\='
 let s:startexp = '[\{\(]\s*$'
-let s:endexp = '[})][\s;]*$'
 
 " Get all syntax types at the beginning of a given line.
 fu! SynSOL(lnum)
@@ -90,7 +89,7 @@ fu! GetTsxIndent()
 
     " Align '/>' and '>' with '<' for multiline tags.
     " Align end of expression ')' or '}'.
-    if l:line =~? s:endtag || l:line =~? s:endexp
+    if l:line =~? s:endtag
       let ind = ind - &sw
     endif
 

--- a/test/tsx.indent.vader
+++ b/test/tsx.indent.vader
@@ -1,0 +1,89 @@
+Given typescriptreact (html end tags):
+  <div>
+  name="cat"
+  value={value}
+  onclick={() => {
+  console.log('hello');
+  }}
+  onremove={() => console.log('bye')}
+  </div>
+
+Do (indent the block):
+  gg=G
+
+Expect typescriptreact indented block:
+  <div>
+  	name="cat"
+  	value={value}
+  	onclick={() => {
+  		console.log('hello');
+  	}}
+  	onremove={() => console.log('bye')}
+  </div>
+
+Given typescriptreact (badly indented component):
+  class MyComponent {
+  	public render() {
+  	return (
+  	<Table disableHeader={false}
+  		key1="123123"
+  		key2="423123"
+  	headerHeight={50}
+  	rowCount={this.state.data.length}
+  	ref="Table"
+  	rowGetter={(row) => this.state.data[row.index]}
+  	rowHeight={30}>
+  	<Column
+  	label="Age"
+  		rowHeight={30}
+  	width={90}
+  	height={100} />
+  	<Column
+  	width={210}
+  	label="Title"
+  	height={100}
+  	/>
+  	<Column
+  	width={210}
+  		label="Title"
+  	height={100} />
+
+  	</Table>
+  	);
+  		}
+  }
+
+Do (indent the block):
+  gg=G
+
+Expect typescriptreact indented blocks:
+  class MyComponent {
+  	public render() {
+  		return (
+  			<Table disableHeader={false}
+  				key1="123123"
+  				key2="423123"
+  				headerHeight={50}
+  				rowCount={this.state.data.length}
+  				ref="Table"
+  				rowGetter={(row) => this.state.data[row.index]}
+  				rowHeight={30}>
+  				<Column
+  					label="Age"
+  					rowHeight={30}
+  					width={90}
+  					height={100} />
+  				<Column
+  					width={210}
+  					label="Title"
+  					height={100}
+  				/>
+  				<Column
+  					width={210}
+  					label="Title"
+  					height={100} />
+
+  			</Table>
+  		);
+  	}
+  }


### PR DESCRIPTION
Indenting a TSX block causes some of the elements' attributes to get unaligned
```
class MyComponent {
    public render() {
        return (
            <Table disableHeader={false}
                key1="123123"
                key2="423123"
            headerHeight={50}
        rowCount={this.state.data.length}
        ref="Table"
    rowGetter={(row) => this.state.data[row.index]}
    rowHeight={30}>
    <Column
        label="Age"
    rowHeight={30}
width={90}
height={100} />
    <Column
    width={210}
    label="Title"
height={100}
    />
    <Column
    width={210}
    label="Title"
    height={100} />

    </Table>
        );
    }
}
```
It seems that the extra check for `endexp` causes this issue, so I removed it.
I do have a feeling that I am missing some edge cases though...
I have also added a new test file for testing TSX indention
