### PR TITLE
Fixed implements keyword after classTypeArguments

### DIFF
--- a/syntax/basic/class.vim
+++ b/syntax/basic/class.vim
@@ -28,7 +28,7 @@ syntax match   typescriptClassHeritage         contained /\v(\k|\.|\(|\))+/
 syntax region typescriptClassTypeArguments matchgroup=typescriptTypeBrackets
   \ start=/</ end=/>/
   \ contains=@typescriptType
-  \ nextgroup=typescriptClassBlock,typescriptMixinComma
+  \ nextgroup=typescriptClassExtends,typescriptClassBlock,typescriptMixinComma
   \ contained skipwhite skipnl
 
 syntax match typescriptMixinComma /,/ contained nextgroup=typescriptClassHeritage skipwhite skipnl

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -446,3 +446,10 @@ Given typescript (comment in while):
   while (/*test*/ss) {}
 Execute:
   AssertEqual 'typescriptComment', SyntaxAt(1, 10)
+
+Given typescript (class expression):
+  var a = class extends Object<any> implements TestInterface {}
+Execute:
+  AssertEqual 'typescriptClassKeyword', SyntaxAt(1, 9)
+  AssertEqual 'typescriptClassExtends', SyntaxAt(1, 15)
+  AssertEqual 'typescriptClassExtends', SyntaxAt(1, 35)


### PR DESCRIPTION
This resolves issue #68 
Let me know if I did something wrong, this is my first time working with the syntax files, but there shouldn't be much to mess up

Screenshot of the file from #68 with this PR
<img width="924" alt="screen shot 2018-08-29 at 21 24 02" src="https://user-images.githubusercontent.com/26621166/44810389-e0a19300-abd1-11e8-8ae4-6d6a33cab09e.png">
