### PR TITLE
TSX Improvements

### DIFF
--- a/ftdetect/tsx.vim
+++ b/ftdetect/tsx.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufRead *.tsx setlocal filetype=typescript.tsx

--- a/ftdetect/typescriptreact.vim
+++ b/ftdetect/typescriptreact.vim
@@ -1,1 +1,0 @@
-autocmd BufNewFile,BufRead *.tsx setlocal filetype=typescriptreact

--- a/indent/tsx.vim
+++ b/indent/tsx.vim
@@ -1,4 +1,3 @@
-exe 'runtime! indent/typescript.vim'
 " Save the current JavaScript indentexpr.
 let b:tsx_ts_indentexpr = &indentexpr
 

--- a/syntax/common.vim
+++ b/syntax/common.vim
@@ -7,7 +7,7 @@ command -nargs=+ HiLink hi def link <args>
 
 "Dollar sign is permitted anywhere in an identifier
 setlocal iskeyword-=$
-if main_syntax == 'typescript' || main_syntax == 'typescriptreact'
+if main_syntax == 'typescript' || main_syntax == 'typescript.tsx'
   setlocal iskeyword+=$
   " syntax cluster htmlJavaScript                 contains=TOP
 endif

--- a/syntax/tsx.vim
+++ b/syntax/tsx.vim
@@ -71,11 +71,13 @@ syntax match tsxTagName
     \ +[</]\_s*[^/!?<>"' ]\++hs=s+1
     \ contained
     \ nextgroup=tsxAttrib
+    \ skipwhite
     \ display
 syntax match tsxIntrinsicTagName
     \ +[</]\_s*[a-z1-9-]\++hs=s+1
     \ contained
     \ nextgroup=tsxAttrib
+    \ skipwhite
     \ display
 
 " <tag key={this.props.key}>

--- a/syntax/tsx.vim
+++ b/syntax/tsx.vim
@@ -70,16 +70,18 @@ syntax match tsxEntityPunct contained "[&.;]"
 syntax match tsxTagName
     \ +[</]\_s*[^/!?<>"' ]\++hs=s+1
     \ contained
+    \ nextgroup=tsxAttrib
     \ display
 syntax match tsxIntrinsicTagName
     \ +[</]\_s*[a-z1-9-]\++hs=s+1
     \ contained
+    \ nextgroup=tsxAttrib
     \ display
 
 " <tag key={this.props.key}>
 "      ~~~
 syntax match tsxAttrib
-    \ +\(\(<\_s*\)\@<!\_s\)\@<=\<[a-zA-Z_][-0-9a-zA-Z_]*\>\(\_s\+\|\_s*[=/>]\)\@=+
+    \ +[a-zA-Z_][-0-9a-zA-Z_]*+
     \ nextgroup=tsxEqual skipwhite
     \ contained
     \ display
@@ -92,10 +94,6 @@ syntax match tsxEqual +=+ display contained
 " <tag id="sample">
 "         s~~~~~~e
 syntax region tsxString contained start=+"+ end=+"+ contains=tsxEntity,@Spell display
-
-" <tag id='sample'>
-"         s~~~~~~e
-syntax region tsxString contained start=+'+ end=+'+ contains=tsxEntity,@Spell display
 
 " <tag key={this.props.key}>
 "          s~~~~~~~~~~~~~~e

--- a/syntax/tsx.vim
+++ b/syntax/tsx.vim
@@ -1,3 +1,5 @@
+" Ported over from https://github.com/mxw/vim-jsx "
+
 if !exists("main_syntax")
   if exists("b:current_syntax") && b:current_syntax != 'typescript'
     finish
@@ -5,122 +7,43 @@ if !exists("main_syntax")
   let main_syntax = 'typescript.tsx'
 endif
 
-syntax region tsxTag
-      \ start=+<\([^/!?<>="':]\+\)\@=+
-      \ skip=+</[^ /!?<>"']\+>+
-      \ end=+/\@<!>+
-      \ end=+\(/>\)\@=+
-      \ contained
-      \ contains=tsxTagName,tsxIntrinsicTagName,tsxAttrib,tsxEscapeJs,
-                \tsxCloseString
+syn include @XMLSyntax syntax/xml.vim
 
-syntax match tsxTag /<>/ contained
+" JSX attributes should color as JS.  Note the trivial end pattern; we let
+" jsBlock take care of ending the region.
+syn region xmlString contained start=+{+ end=++ contains=typescriptBlock
 
+" JSX comments inside XML tag should color as comment.  Note the trivial end pattern; we let
+" jsComment take care of ending the region.
+syn region xmlString contained start=+//+ end=++ contains=typescriptComment
 
-" <tag></tag>
-" s~~~~~~~~~e
-" and self close tag
-" <tag/>
-" s~~~~e
-" A big start regexp borrowed from https://git.io/vDyxc
-syntax region tsxRegion
-      \ start=+<\_s*\z([a-zA-Z1-9\$_-]\+\(\.\k\+\)*\)+
-      \ skip=+<!--\_.\{-}-->+
-      \ end=+</\_s*\z1>+
-      \ matchgroup=tsxCloseString end=+/>+
-      \ fold
-      \ contains=tsxRegion,tsxCloseString,tsxCloseTag,tsxTag,tsxComment,tsxFragment,tsxEscapeJs,@Spell
-      \ keepend
-      \ extend
+" JSX child blocks behave just like JSX attributes, except that (a) they are
+" syntactically distinct, and (b) they need the syn-extend argument, or else
+" nested XML end-tag patterns may end the outer jsxRegion.
+syn region tsxChild contained start=+{+ end=++ contains=typescriptBlock
+  \ extend
 
-" <>   </>
-" s~~~~~~e
-" A big start regexp borrowed from https://git.io/vDyxc
-syntax region tsxFragment
-      \ start=+\(\((\|{\|}\|\[\|,\|&&\|||\|?\|:\|=\|=>\|\Wreturn\|^return\|\Wdefault\|^\|>\)\_s*\)\@<=<>+
-      \ skip=+<!--\_.\{-}-->+
-      \ end=+</>+
-      \ fold
-      \ contains=tsxRegion,tsxCloseString,tsxCloseTag,tsxTag,tsxComment,tsxFragment,tsxEscapeJs,@Spell
-      \ keepend
-      \ extend
+" Highlight JSX regions as XML; recursively match.
+"
+" Note that we prohibit JSX tags from having a < or word character immediately
+" preceding it, to avoid conflicts with, respectively, the left shift operator
+" and generic Flow type annotations (http://flowtype.org/).
+syn region tsxRegion
+  \ contains=@Spell,@XMLSyntax,tsxRegion,tsxChild,typescriptBlock
+  \ start=+\%(<\|\w\)\@<!<\z([a-zA-Z_][a-zA-Z0-9:\-.]*\>[:,]\@!\)\([^>]*>(\)\@!+
+  \ skip=+<!--\_.\{-}-->+
+  \ end=+</\z1\_\s\{-}>+
+  \ end=+/>+
+  \ keepend
+  \ extend
 
-" </tag>
-" ~~~~~~
-syntax match tsxCloseTag
-      \ +</\_s*[^/!?<>"']\+>+
-      \ contained
-      \ contains=tsxTagName,tsxIntrinsicTagName
+" Add jsxRegion to the lowest-level JS syntax cluster.
+syn cluster typescriptExpression add=tsxRegion
 
-syntax match tsxCloseTag +</>+ contained
-
-syntax match tsxCloseString
-      \ +/>+
-      \ contained
-
-" <!-- -->
-" ~~~~~~~~
-syntax match tsxComment /<!--\_.\{-}-->/ display
-
-syntax match tsxEntity "&[^; \t]*;" contains=tsxEntityPunct
-syntax match tsxEntityPunct contained "[&.;]"
-
-" <tag key={this.props.key}>
-"  ~~~
-syntax match tsxTagName
-    \ +[</]\_s*[^/!?<>"' ]\++hs=s+1
-    \ contained
-    \ display
-syntax match tsxIntrinsicTagName
-    \ +[</]\_s*[a-z1-9-]\++hs=s+1
-    \ contained
-    \ display
-
-" <tag key={this.props.key}>
-"      ~~~
-syntax match tsxAttrib
-    \ +\(\(<\_s*\)\@<!\_s\)\@<=\<[a-zA-Z_][-0-9a-zA-Z_]*\>\(\_s\+\|\_s*[=/>]\)\@=+
-    \ nextgroup=tsxEqual skipwhite
-    \ contained
-    \ display
-
-" <tag id="sample">
-"        ~
-syntax match tsxEqual +=+ display contained
-  \ nextgroup=tsxString skipwhite
-
-" <tag id="sample">
-"         s~~~~~~e
-syntax region tsxString contained start=+"+ end=+"+ contains=tsxEntity,@Spell display
-
-" <tag id='sample'>
-"         s~~~~~~e
-syntax region tsxString contained start=+'+ end=+'+ contains=tsxEntity,@Spell display
-
-" <tag key={this.props.key}>
-"          s~~~~~~~~~~~~~~e
-syntax region tsxEscapeJs
-    \ contained
-    \ contains=@typescriptExpression
-    \ start=+{+
-    \ end=+}+
-    \ extend
-
+" Allow jsxRegion to contain reserved words.
+"syn cluster javascriptNoReserved add=jsxRegion
 
 runtime syntax/common.vim
-
-syntax cluster typescriptExpression add=tsxRegion,tsxFragment
-
-highlight def link tsxTag htmlTag
-highlight def link tsxTagName Function
-highlight def link tsxIntrinsicTagName htmlTagName
-highlight def link tsxString String
-highlight def link tsxNameSpace Function
-highlight def link tsxComment Error
-highlight def link tsxAttrib Type
-highlight def link tsxEscapeJs tsxEscapeJs
-highlight def link tsxCloseTag htmlTag
-highlight def link tsxCloseString Identifier
 
 let b:current_syntax = "typescript.tsx"
 if main_syntax == 'typescript.tsx'

--- a/syntax/tsx.vim
+++ b/syntax/tsx.vim
@@ -104,9 +104,6 @@ syntax region tsxEscapeJs
     \ end=+}+
     \ extend
 
-
-runtime syntax/common.vim
-
 syntax cluster typescriptExpression add=tsxRegion,tsxFragment
 
 highlight def link tsxTag htmlTag

--- a/syntax/tsx.vim
+++ b/syntax/tsx.vim
@@ -1,8 +1,8 @@
 if !exists("main_syntax")
-  if exists("b:current_syntax")
+  if exists("b:current_syntax") && b:current_syntax != 'typescript'
     finish
   endif
-  let main_syntax = 'typescriptreact'
+  let main_syntax = 'typescript.tsx'
 endif
 
 syntax region tsxTag
@@ -122,7 +122,7 @@ highlight def link tsxEscapeJs tsxEscapeJs
 highlight def link tsxCloseTag htmlTag
 highlight def link tsxCloseString Identifier
 
-let b:current_syntax = "typescriptreact"
-if main_syntax == 'typescriptreact'
+let b:current_syntax = "typescript.tsx"
+if main_syntax == 'typescript.tsx'
   unlet main_syntax
 endif

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -2,6 +2,10 @@ var fragment = <div sdss="123" ></div>
 var b = <Div sss="123"></Div>
 var a = 123
 var a=  <Option key={item}></Option>;
+var a=  <Option       key={item}
+    value="test"
+>
+</Option>;
 
 var a = <React.Fragment>
       {

--- a/test/tsx.indent.vader
+++ b/test/tsx.indent.vader
@@ -1,4 +1,4 @@
-Given typescriptreact (html end tags):
+Given typescript.tsx (html end tags):
   <div>
   name="cat"
   value={value}
@@ -11,7 +11,7 @@ Given typescriptreact (html end tags):
 Do (indent the block):
   gg=G
 
-Expect typescriptreact indented block:
+Expect typescript.tsx indented block:
   <div>
   	name="cat"
   	value={value}
@@ -21,7 +21,7 @@ Expect typescriptreact indented block:
   	onremove={() => console.log('bye')}
   </div>
 
-Given typescriptreact (badly indented component):
+Given typescript.tsx (badly indented component):
   class MyComponent {
   	public render() {
   	return (
@@ -56,7 +56,7 @@ Given typescriptreact (badly indented component):
 Do (indent the block):
   gg=G
 
-Expect typescriptreact indented blocks:
+Expect typescript.tsx indented blocks:
   class MyComponent {
   	public render() {
   		return (

--- a/test/tsx.indent.vader
+++ b/test/tsx.indent.vader
@@ -87,3 +87,88 @@ Expect typescript.tsx indented blocks:
   		);
   	}
   }
+
+Given typescript.tsx (badly indented component + non tsx):
+    interface MyComponentProps {
+  first: string;
+    second: boolean;
+             third: {
+                [key: string]: string | number;
+        count: number;
+                };
+        }
+
+  class MyComponent {
+  	public render() {
+  	return (
+  	<Table disableHeader={false}
+  		key1="123123"
+  		key2="423123"
+  	headerHeight={50}
+  	rowCount={this.state.data.length}
+  	ref="Table"
+  	rowGetter={(row) => this.state.data[row.index]}
+  	rowHeight={30}>
+  	<Column
+  	label="Age"
+  		rowHeight={30}
+  	width={90}
+  	height={100} />
+  	<Column
+  	width={210}
+  	label="Title"
+  	height={100}
+  	/>
+  	<Column
+  	width={210}
+  		label="Title"
+  	height={100} />
+
+  	</Table>
+  	);
+  		}
+  }
+
+Do (indent the block):
+  gg=G
+
+Expect typescript.tsx indented blocks:
+  interface MyComponentProps {
+  	first: string;
+  	second: boolean;
+  	third: {
+  		[key: string]: string | number;
+  		count: number;
+  	};
+  }
+
+  class MyComponent {
+  	public render() {
+  		return (
+  			<Table disableHeader={false}
+  				key1="123123"
+  				key2="423123"
+  				headerHeight={50}
+  				rowCount={this.state.data.length}
+  				ref="Table"
+  				rowGetter={(row) => this.state.data[row.index]}
+  				rowHeight={30}>
+  				<Column
+  					label="Age"
+  					rowHeight={30}
+  					width={90}
+  					height={100} />
+  				<Column
+  					width={210}
+  					label="Title"
+  					height={100}
+  				/>
+  				<Column
+  					width={210}
+  					label="Title"
+  					height={100} />
+
+  			</Table>
+  		);
+  	}
+  }

--- a/test/tsx.vader
+++ b/test/tsx.vader
@@ -1,4 +1,4 @@
-Given typescriptreact (basic usage):
+Given typescript.tsx (basic usage):
   var a = <div></div>
   var b = 123
 
@@ -7,7 +7,7 @@ Execute:
   AssertEqual 'tsxIntrinsicTagName', SyntaxAt(1, 10)
   AssertEqual 'typescriptVariable', SyntaxAt(2, 1)
 
-Given typescriptreact (basic void):
+Given typescript.tsx (basic void):
   var a = <img/>
   var b = 123
 
@@ -16,7 +16,7 @@ Execute:
   AssertEqual 'tsxIntrinsicTagName', SyntaxAt(1, 10)
   AssertEqual 'typescriptVariable', SyntaxAt(2, 1)
 
-Given typescriptreact (interpolation):
+Given typescript.tsx (interpolation):
   var a = <Option key={item}></Option>;
   var b = 123
 
@@ -25,7 +25,7 @@ Execute:
   AssertEqual 'tsxTagName', SyntaxAt(1, 30)
   AssertEqual 'typescriptVariable', SyntaxAt(2, 1)
 
-Given typescriptreact (custom component):
+Given typescript.tsx (custom component):
   var a = <ion-gesture></ion-gesture>;
   var b = 123
 
@@ -34,7 +34,7 @@ Execute:
   AssertEqual 'tsxIntrinsicTagName', SyntaxAt(1, 30)
   AssertEqual 'typescriptVariable', SyntaxAt(2, 1)
 
-Given typescriptreact (digit in tagname):
+Given typescript.tsx (digit in tagname):
   var a = <h1></h1>;
   var b = 123
 
@@ -43,7 +43,7 @@ Execute:
   AssertEqual 'tsxIntrinsicTagName', SyntaxAt(1, 16)
   AssertEqual 'typescriptVariable', SyntaxAt(2, 1)
 
-Given typescriptreact (paren + render props):
+Given typescript.tsx (paren + render props):
   var d =  (
     <Route component={() => <Home/>}/>
   )

--- a/test/tsx.vader
+++ b/test/tsx.vader
@@ -50,3 +50,28 @@ Given typescript.tsx (paren + render props):
 
 Execute:
   AssertEqual 'tsxTagName', SyntaxAt(2, 4)
+
+Given typescript.tsx (attributes):
+  var d = <Route component={() => <Home/>}
+    another-attribute="1"
+  />
+
+Execute:
+  AssertEqual 'tsxTagName', SyntaxAt(1, 10)
+  AssertEqual 'tsxTagName', SyntaxAt(1, 34)
+  AssertEqual 'tsxAttrib', SyntaxAt(1, 16)
+  AssertEqual 'tsxAttrib', SyntaxAt(2, 3)
+  AssertEqual 'tsxAttrib', SyntaxAt(2, 11)
+
+Given typescript.tsx (paren + attributes):
+  var d = (
+    <Route component={() => <Home/>}
+      another-attribute="1"
+    />
+  )
+
+Execute:
+  AssertEqual 'tsxAttrib', SyntaxAt(2, 10)
+  AssertEqual 'tsxTagName', SyntaxAt(2, 28)
+  AssertEqual 'tsxAttrib', SyntaxAt(3, 5)
+  AssertEqual 'tsxAttrib', SyntaxAt(3, 13)


### PR DESCRIPTION
Renamed `typescriptreact` -> `typescript.tsx`, allowing combined syntax
Changed `tsxAttrib` regex, which improved performance even with `relativenumber` set - this may need revision, I'm not sure why the previous regex was so complicated. (#25)
Added tests for `tsxAttrib`