### PR TITLE
Multiple fixes, changed semicolons and commas

### DIFF
--- a/syntax/basic/class.vim
+++ b/syntax/basic/class.vim
@@ -36,7 +36,7 @@ syntax match typescriptMixinComma /,/ contained nextgroup=typescriptClassHeritag
 " we need add arrowFunc to class block for high order arrow func
 " see test case
 syntax region  typescriptClassBlock matchgroup=typescriptBraces start=/{/ end=/}/
-  \ contains=@typescriptPropertyMemberDeclaration,typescriptAbstract,@typescriptComments,typescriptBlock,typescriptAssign,typescriptDecorator,typescriptAsyncFuncKeyword,typescriptArrowFunc
+  \ contains=@typescriptPropertyMemberDeclaration,typescriptAbstract,@typescriptComments,typescriptBlock,typescriptAssign,typescriptDecorator,typescriptAsyncFuncKeyword,typescriptArrowFunc,@typescriptSymbols
   \ contained fold
 
 syntax keyword typescriptInterfaceKeyword          interface nextgroup=typescriptInterfaceName skipwhite

--- a/syntax/basic/keyword.vim
+++ b/syntax/basic/keyword.vim
@@ -78,6 +78,7 @@ syntax region  typescriptConditionalParen             contained matchgroup=types
   \ nextgroup=typescriptBlock
   \ skipwhite skipempty
 syntax match   typescriptEndColons             /[;,]/
+syntax cluster typescriptSymbols add=typescriptEndColons
 
 syntax keyword typescriptAmbientDeclaration declare nextgroup=@typescriptAmbients
   \ skipwhite skipempty

--- a/syntax/basic/keyword.vim
+++ b/syntax/basic/keyword.vim
@@ -77,7 +77,7 @@ syntax region  typescriptConditionalParen             contained matchgroup=types
   \ contains=@typescriptValue,@typescriptComments
   \ nextgroup=typescriptBlock
   \ skipwhite skipempty
-syntax match   typescriptEndColons             /[;,]/
+syntax match   typescriptEndColons             /[;,]/ contained
 
 syntax keyword typescriptAmbientDeclaration declare nextgroup=@typescriptAmbients
   \ skipwhite skipempty

--- a/syntax/basic/keyword.vim
+++ b/syntax/basic/keyword.vim
@@ -78,7 +78,6 @@ syntax region  typescriptConditionalParen             contained matchgroup=types
   \ nextgroup=typescriptBlock
   \ skipwhite skipempty
 syntax match   typescriptEndColons             /[;,]/
-syntax cluster typescriptSymbols add=typescriptEndColons
 
 syntax keyword typescriptAmbientDeclaration declare nextgroup=@typescriptAmbients
   \ skipwhite skipempty

--- a/syntax/basic/members.vim
+++ b/syntax/basic/members.vim
@@ -38,6 +38,6 @@ syntax region  typescriptStringMember   contained
 
 syntax region  typescriptComputedMember   contained matchgroup=typescriptProperty
   \ start=/\[/rs=s+1 end=/]/
-  \ contains=@typescriptValue
+  \ contains=typescriptMember
   \ nextgroup=@memberNextGroup
   \ skipwhite skipempty

--- a/syntax/basic/members.vim
+++ b/syntax/basic/members.vim
@@ -38,6 +38,6 @@ syntax region  typescriptStringMember   contained
 
 syntax region  typescriptComputedMember   contained matchgroup=typescriptProperty
   \ start=/\[/rs=s+1 end=/]/
-  \ contains=typescriptMember
+  \ contains=@typescriptValue,typescriptMember
   \ nextgroup=@memberNextGroup
   \ skipwhite skipempty

--- a/syntax/basic/symbols.vim
+++ b/syntax/basic/symbols.vim
@@ -3,7 +3,7 @@ syntax match typescriptUnaryOp /[+\-~!]/
  \ nextgroup=@typescriptValue
  \ skipwhite
 
-syntax region  typescriptTernaryOp start=/?/  end=/:/ contained contains=@typescriptValue,@typescriptComments nextgroup=@typescriptValue skipwhite skipempty
+syntax region typescriptTernary matchgroup=typescriptTernaryOp start=/?/ end=/:/ contained contains=@typescriptValue,@typescriptComments nextgroup=@typescriptValue skipwhite skipempty
 
 syntax match   typescriptAssign  /=/ nextgroup=@typescriptValue
   \ skipwhite skipempty
@@ -35,4 +35,4 @@ syntax match   typescriptBinaryOp contained /-\(-\|=\)\?/ nextgroup=@typescriptV
 " 2: **, **=
 syntax match typescriptBinaryOp contained /\*\*=\?/ nextgroup=@typescriptValue
 
-syntax cluster typescriptSymbols               contains=typescriptBinaryOp,typescriptKeywordOp,typescriptTernaryOp,typescriptAssign,typescriptCastKeyword
+syntax cluster typescriptSymbols               contains=typescriptBinaryOp,typescriptKeywordOp,typescriptTernary,typescriptAssign,typescriptCastKeyword

--- a/syntax/basic/symbols.vim
+++ b/syntax/basic/symbols.vim
@@ -36,5 +36,6 @@ syntax match   typescriptBinaryOp contained /-\(-\|=\)\?/ nextgroup=@typescriptV
 syntax match typescriptBinaryOp contained /\*\*=\?/ nextgroup=@typescriptValue
 
 syntax match typescriptSemicolons /;/
+syntax match typescriptCommas /,/
 
-syntax cluster typescriptSymbols               contains=typescriptBinaryOp,typescriptKeywordOp,typescriptTernary,typescriptAssign,typescriptCastKeyword,typescriptSemicolons
+syntax cluster typescriptSymbols               contains=typescriptBinaryOp,typescriptKeywordOp,typescriptTernary,typescriptAssign,typescriptCastKeyword,typescriptSemicolons,typescriptCommas

--- a/syntax/basic/symbols.vim
+++ b/syntax/basic/symbols.vim
@@ -35,4 +35,6 @@ syntax match   typescriptBinaryOp contained /-\(-\|=\)\?/ nextgroup=@typescriptV
 " 2: **, **=
 syntax match typescriptBinaryOp contained /\*\*=\?/ nextgroup=@typescriptValue
 
-syntax cluster typescriptSymbols               contains=typescriptBinaryOp,typescriptKeywordOp,typescriptTernary,typescriptAssign,typescriptCastKeyword
+syntax match typescriptSemicolons /;/
+
+syntax cluster typescriptSymbols               contains=typescriptBinaryOp,typescriptKeywordOp,typescriptTernary,typescriptAssign,typescriptCastKeyword,typescriptSemicolons

--- a/syntax/basic/type.vim
+++ b/syntax/basic/type.vim
@@ -72,7 +72,7 @@ syntax match typescriptTypeReference /\K\k*\(\.\K\k*\)*/
 
 syntax region typescriptObjectType matchgroup=typescriptBraces
   \ start=/{/ end=/}/
-  \ contains=@typescriptTypeMember,@typescriptComments,typescriptAccessibilityModifier
+  \ contains=@typescriptTypeMember,typescriptEndColons,@typescriptComments,typescriptAccessibilityModifier
   \ nextgroup=@typescriptTypeOperator
   \ contained skipwhite fold
 

--- a/syntax/common.vim
+++ b/syntax/common.vim
@@ -44,6 +44,8 @@ if exists("did_typescript_hilink")
   HiLink typescriptReserved             Error
 
   HiLink typescriptEndColons            Exception
+  HiLink typescriptSemicolons           typescriptEndColons
+  HiLink typescriptCommas               typescriptSemicolons
   HiLink typescriptSymbols              Normal
   HiLink typescriptBraces               Function
   HiLink typescriptParens               Normal

--- a/syntax/common.vim
+++ b/syntax/common.vim
@@ -16,7 +16,7 @@ endif
 syntax match   typescriptLabel                /[a-zA-Z_$]\k*:/he=e-1 contains=typescriptReserved nextgroup=@typescriptStatement skipwhite skipempty
 
 " other keywords like return,case,yield uses containedin
-syntax region  typescriptBlock                 matchgroup=typescriptBraces start=/{/ end=/}/ contains=@typescriptStatement,@typescriptComments fold
+syntax region  typescriptBlock                 matchgroup=typescriptBraces start=/{/ end=/}/ contains=@typescriptStatement,@typescriptSymbols,@typescriptComments fold
 
 
 runtime syntax/basic/identifiers.vim

--- a/syntax/tsx.vim
+++ b/syntax/tsx.vim
@@ -102,6 +102,7 @@ syntax region tsxString contained start=+"+ end=+"+ contains=tsxEntity,@Spell di
 syntax region tsxEscapeJs
     \ contained
     \ contains=@typescriptExpression
+    \ matchgroup=typescriptBraces
     \ start=+{+
     \ end=+}+
     \ extend


### PR DESCRIPTION
Fixed multiple issues (#72, #73, #74, #75)
Changed highlighting of semicolons `;` and commas `,`:

There are now 3 highlight groups:
- `typescriptEndColons` - Remains as is, but fixed it's container. Contains both `;` and `,` but only inside typescript type/interface definition
- `typescriptSemicolons` - Contains all other `;`, it's highlight is linked to `typescriptEndColons`
- `typescriptCommas` - Contains all other `,`, it's highlight is linked to `typescriptSemicolons`

This is a subject to change, I'm not sure if it's the best approach, but to me it provides a lot of flexibility if the user wants to change highlight. If we just want them united, I can remove the 2 new groups and just add `typescriptEndColons` to symbols.