### PR TITLE
Fixed typescriptEndColons

### DIFF
--- a/syntax/basic/keyword.vim
+++ b/syntax/basic/keyword.vim
@@ -77,7 +77,7 @@ syntax region  typescriptConditionalParen             contained matchgroup=types
   \ contains=@typescriptValue,@typescriptComments
   \ nextgroup=typescriptBlock
   \ skipwhite skipempty
-syntax match   typescriptEndColons             /[;,]/
+syntax match   typescriptEndColons             /[;,]/ contained
 
 syntax keyword typescriptAmbientDeclaration declare nextgroup=@typescriptAmbients
   \ skipwhite skipempty

--- a/syntax/basic/type.vim
+++ b/syntax/basic/type.vim
@@ -72,7 +72,7 @@ syntax match typescriptTypeReference /\K\k*\(\.\K\k*\)*/
 
 syntax region typescriptObjectType matchgroup=typescriptBraces
   \ start=/{/ end=/}/
-  \ contains=@typescriptTypeMember,@typescriptComments,typescriptAccessibilityModifier
+  \ contains=@typescriptTypeMember,typescriptEndColons,@typescriptComments,typescriptAccessibilityModifier
   \ nextgroup=@typescriptTypeOperator
   \ contained skipwhite fold
 


### PR DESCRIPTION
By investigating for #73 I found out that group `typescriptEndColons` is not highlighted properly. This PR fixes it, but as stated in #76, if we do not want to highlight these at all, this group could be removed.