### PR TITLE
Fixed newline extends for generic interface

### DIFF
--- a/syntax/basic/class.vim
+++ b/syntax/basic/class.vim
@@ -48,7 +48,7 @@ syntax region typescriptInterfaceTypeParameter
   \ contains=typescriptTypeParameter
   \ nextgroup=typescriptObjectType,typescriptInterfaceExtends
   \ contained
-  \ skipwhite
+  \ skipwhite skipnl
 
 syntax keyword typescriptInterfaceExtends          contained extends nextgroup=typescriptInterfaceHeritage skipwhite skipnl
 

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -458,3 +458,9 @@ Given typescript (export interface):
   export default interface A {}
 Execute:
   AssertEqual 'typescriptInterfaceKeyword', SyntaxAt(1, 16)
+
+Given typescript (interface extends with newline):
+  interface SomeRandomLongName<Parameter1, Parameter2, Parameter3>
+      extends SomeOtherInterface {}
+Execute:
+  AssertEqual 'typescriptInterfaceExtends', SyntaxAt(2, 5)


### PR DESCRIPTION
Previously, if there was a generic interface with a long name/lots of parameters and for readabilty it's `extends` part was moved to another line, the highlight would break.

In short: `typescriptInterfaceTypeParameter` was missing `skipnl`, I've also added a test for this case.