### PR TITLE
Fixed "static async" & computed member "in" highlight

### DIFF
--- a/syntax/basic/members.vim
+++ b/syntax/basic/members.vim
@@ -26,7 +26,7 @@ syntax match typescriptMemberOptionality /?\|!/ contained
 syntax cluster typescriptMembers contains=typescriptMember,typescriptStringMember,typescriptComputedMember
 
 syntax keyword typescriptClassStatic static
-  \ nextgroup=@typescriptMembers
+  \ nextgroup=@typescriptMembers,typescriptAsyncFuncKeyword
   \ skipwhite contained
 
 syntax keyword typescriptAccessibilityModifier public private protected readonly contained

--- a/syntax/basic/members.vim
+++ b/syntax/basic/members.vim
@@ -38,6 +38,6 @@ syntax region  typescriptStringMember   contained
 
 syntax region  typescriptComputedMember   contained matchgroup=typescriptProperty
   \ start=/\[/rs=s+1 end=/]/
-  \ contains=@typescriptValue,typescriptMember
+  \ contains=@typescriptValue,typescriptMember,typescriptMappedIn
   \ nextgroup=@memberNextGroup
   \ skipwhite skipempty


### PR DESCRIPTION
"static async" functions were broken, they were getting highlight with "async static" but that's invalid syntax.

Also computed members with something like this:
```typescript
type MyMappedType = {
    [key in SomeOtherType]: string;
}
```
were not highlighted correctly, everything inside `[]` was in one color.