### PR TITLE
Added matchit plugin jump between jsx tags support

### DIFF
--- a/ftplugin/tsx.vim
+++ b/ftplugin/tsx.vim
@@ -1,0 +1,11 @@
+" modified from mxw/vim-jsx from html.vim
+if exists("loaded_matchit")
+  let b:match_ignorecase = 0
+  let s:tsx_match_words = '(:),\[:\],{:},<:>,' .
+        \ '<\@<=\([^/][^ \t>]*\)[^>]*\%(/\@<!>\|$\):<\@<=/\1>'
+  let b:match_words = exists('b:match_words')
+    \ ? b:match_words . ',' . s:tsx_match_words
+    \ : s:tsx_match_words
+endif
+
+set suffixesadd+=.tsx


### PR DESCRIPTION
* Extends `b:matchwords` so matchit can match jsx tags.

The matchit plugin extends '%' matching to support html/xml tags. 
When enabled and the cursor is on the opening or closing tag,
pressing '%' will jump to the matching closing or opening tag. The
built in matchit plugin can be enabled by adding the following to
your vimrc:
  `runtime macros/matchit.vim`