### PR TITLE
Add workaround for highlighting matching brackets with matchparen

### DIFF
--- a/syntax/tsx.vim
+++ b/syntax/tsx.vim
@@ -11,7 +11,7 @@ syntax region tsxTag
       \ end=+/\@<!>+
       \ end=+\(/>\)\@=+
       \ contained
-      \ contains=tsxTagName,tsxIntrinsicTagName,tsxAttrib,tsxEscapeJs,
+      \ contains=tsxTagName,tsxIntrinsicTagName,tsxAttrib,tsxEscJs,
                 \tsxCloseString
 
 syntax match tsxTag /<>/ contained
@@ -29,7 +29,7 @@ syntax region tsxRegion
       \ end=+</\_s*\z1>+
       \ matchgroup=tsxCloseString end=+/>+
       \ fold
-      \ contains=tsxRegion,tsxCloseString,tsxCloseTag,tsxTag,tsxComment,tsxFragment,tsxEscapeJs,@Spell
+      \ contains=tsxRegion,tsxCloseString,tsxCloseTag,tsxTag,tsxComment,tsxFragment,tsxEscJs,@Spell
       \ keepend
       \ extend
 
@@ -41,7 +41,7 @@ syntax region tsxFragment
       \ skip=+<!--\_.\{-}-->+
       \ end=+</>+
       \ fold
-      \ contains=tsxRegion,tsxCloseString,tsxCloseTag,tsxTag,tsxComment,tsxFragment,tsxEscapeJs,@Spell
+      \ contains=tsxRegion,tsxCloseString,tsxCloseTag,tsxTag,tsxComment,tsxFragment,tsxEscJs,@Spell
       \ keepend
       \ extend
 
@@ -99,7 +99,7 @@ syntax region tsxString contained start=+"+ end=+"+ contains=tsxEntity,@Spell di
 
 " <tag key={this.props.key}>
 "          s~~~~~~~~~~~~~~e
-syntax region tsxEscapeJs
+syntax region tsxEscJs
     \ contained
     \ contains=@typescriptExpression
     \ matchgroup=typescriptBraces
@@ -117,6 +117,7 @@ highlight def link tsxNameSpace Function
 highlight def link tsxComment Error
 highlight def link tsxAttrib Type
 highlight def link tsxEscapeJs tsxEscapeJs
+highlight def link tsxEscJs tsxEscapeJs
 highlight def link tsxCloseTag htmlTag
 highlight def link tsxCloseString Identifier
 


### PR DESCRIPTION
* Rename `tsxEscapeJs` syntax type to `tsxEscJs` as a work around to
mismatching bracket highlighting.
* Alias `tsxEscJs` to `tsxEscapeJs` to keep backward compatability for
styling.

The built in plugin matchparen (enabled by default on most systems)
highlights the matching paren when the cursor is over a bracket. The 
matching relies on syntax types (when enabled) and is configured to
exclude any syntax types containing the words
`string\\|character\\|singlequote\\|escape\\|comment` from the matching
process.

This would cause a `tsxEscapeJs` region to mismatch highlighting for
that region and the overlapping regions bounded by braces.