### PR TITLE
Add syntax to object as nextgroup after `tsxEscapeJs`

### DIFF
--- a/syntax/tsx.vim
+++ b/syntax/tsx.vim
@@ -101,7 +101,7 @@ syntax region tsxString contained start=+"+ end=+"+ contains=tsxEntity,@Spell di
 "          s~~~~~~~~~~~~~~e
 syntax region tsxEscapeJs
     \ contained
-    \ contains=@typescriptExpression
+    \ contains=@typescriptExpression,typescriptObjectLiteral
     \ matchgroup=typescriptBraces
     \ start=+{+
     \ end=+}+

--- a/test/tsx.vader
+++ b/test/tsx.vader
@@ -75,3 +75,12 @@ Execute:
   AssertEqual 'tsxTagName', SyntaxAt(2, 28)
   AssertEqual 'tsxAttrib', SyntaxAt(3, 5)
   AssertEqual 'tsxAttrib', SyntaxAt(3, 13)
+
+Given typescript.tsx (object in jsx attribute):
+  var d = <Route component={{ test: 1 }}
+    another-attribute="1"
+  />
+
+Execute:
+  AssertEqual 'typescriptObjectLiteral', SyntaxAt(1, 28)
+  AssertEqual 'typescriptObjectLabel', SyntaxAt(1, 29)


### PR DESCRIPTION
* Fix an object as the first expression in a `tsxEscapeJs` region not
being marked as a `typescriptObjectLiteral` syntax type.
* Add a vader test for this case.