### PR TITLE
fix syntax in module declarations

### DIFF
--- a/syntax/basic/cluster.vim
+++ b/syntax/basic/cluster.vim
@@ -6,7 +6,8 @@ syntax cluster typescriptStatement
   \ typescriptLabel,typescriptStatementKeyword,
   \ typescriptFuncKeyword,
   \ typescriptTry,typescriptExceptions,typescriptDebugger,
-  \ typescriptExport,typescriptInterfaceKeyword,typescriptEnum,typescriptModule
+  \ typescriptExport,typescriptInterfaceKeyword,typescriptEnum,
+  \ typescriptModule,typescriptAliasKeyword,typescriptImport
 
 syntax cluster typescriptPrimitive  contains=typescriptString,typescriptTemplate,typescriptRegexpString,typescriptNumber,typescriptBoolean,typescriptNull,typescriptArray
 

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -85,6 +85,20 @@ Execute:
   AssertEqual 'typescriptAmbientDeclaration', SyntaxAt(1, 1)
   AssertEqual 'typescriptAmbientDeclaration', SyntaxAt(2, 1)
 
+Given typescript (declare module with imports):
+  declare module 'foo' {
+    import { Foo, Bar } from 'foobar';
+  }
+Execute:
+  AssertEqual 'typescriptImport', SyntaxAt(2, 3)
+
+Given typescript (declare module with types):
+  declare module 'foo' {
+    type FooBar = 'foo' | 'bar';
+  }
+Execute:
+  AssertEqual 'typescriptAliasKeyword', SyntaxAt(2, 3)
+
 Given typescript (double ambient declare):
   function test() {
     return { name: 123, }


### PR DESCRIPTION
This PR simply fixes a small issue in module declarations.

An example of the problem can be seen by typing this in your editor:

```ts
declare module 'foo' {
    import { Foo, Bar } from 'foobar';

    type FooBar = Foo | Bar;
}
```

Let me know if you have any questions.