### PR TITLE
add fold to types with parens

### DIFF
--- a/syntax/basic/type.vim
+++ b/syntax/basic/type.vim
@@ -60,7 +60,7 @@ syntax region typescriptParenthesizedType matchgroup=typescriptParens
   \ start=/(/ end=/)/
   \ contains=@typescriptType
   \ nextgroup=@typescriptTypeOperator
-  \ contained skipwhite skipempty
+  \ contained skipwhite skipempty fold
 
 syntax keyword typescriptPredefinedType any number boolean string void never undefined null object unknown
   \ nextgroup=@typescriptTypeOperator


### PR DESCRIPTION
Hello again.

This one is pretty simple. It just adds `fold` to multiline types with parens.

In other words...

```ts
type Foo = (
    bar: string,
    baz: number,
    qux: any,
) => void;
```

All of the above is folded.

Let me know if you have any questions or would like me to add a test for this.