### PR TITLE
fix readonly modifier in class properties

### DIFF
--- a/syntax/basic/members.vim
+++ b/syntax/basic/members.vim
@@ -15,6 +15,7 @@ syntax match typescriptMethodAccessor contained /\v(get|set)\s\K/me=e-1
 syntax cluster typescriptPropertyMemberDeclaration contains=
   \ typescriptClassStatic,
   \ typescriptAccessibilityModifier,
+  \ typescriptReadonlyModifier,
   \ typescriptMethodAccessor,
   \ @typescriptMembers
   " \ typescriptMemberVariableDeclaration
@@ -26,10 +27,12 @@ syntax match typescriptMemberOptionality /?\|!/ contained
 syntax cluster typescriptMembers contains=typescriptMember,typescriptStringMember,typescriptComputedMember
 
 syntax keyword typescriptClassStatic static
-  \ nextgroup=@typescriptMembers,typescriptAsyncFuncKeyword
+  \ nextgroup=@typescriptMembers,typescriptAsyncFuncKeyword,typescriptReadonlyModifier
   \ skipwhite contained
 
-syntax keyword typescriptAccessibilityModifier public private protected readonly contained
+syntax keyword typescriptAccessibilityModifier public private protected contained
+
+syntax keyword typescriptReadonlyModifier readonly contained
 
 syntax region  typescriptStringMember   contained
   \ start=/\z(["']\)/  skip=/\\\\\|\\\z1\|\\\n/  end=/\z1/

--- a/syntax/basic/type.vim
+++ b/syntax/basic/type.vim
@@ -72,7 +72,7 @@ syntax match typescriptTypeReference /\K\k*\(\.\K\k*\)*/
 
 syntax region typescriptObjectType matchgroup=typescriptBraces
   \ start=/{/ end=/}/
-  \ contains=@typescriptTypeMember,typescriptEndColons,@typescriptComments,typescriptAccessibilityModifier
+  \ contains=@typescriptTypeMember,typescriptEndColons,@typescriptComments,typescriptAccessibilityModifier,typescriptReadonlyModifier
   \ nextgroup=@typescriptTypeOperator
   \ contained skipwhite fold
 

--- a/syntax/common.vim
+++ b/syntax/common.vim
@@ -123,6 +123,7 @@ if exists("did_typescript_hilink")
   " HiLink typescriptClassHeritage        Function
   " HiLink typescriptInterfaceHeritage    Function
   HiLink typescriptClassStatic          StorageClass
+  HiLink typescriptReadonlyModifier     Keyword
   HiLink typescriptInterfaceKeyword     Keyword
   HiLink typescriptInterfaceExtends     Keyword
   HiLink typescriptInterfaceName        Function


### PR DESCRIPTION
This PR fixes a small issue with `readonly` that can be reproduced with the following snippet:

```ts
export class Foo {
    static foo: number;
    private static readonly bar: string;
    protected static readonly qux = async () => void 0;
    readonly quux: string;
    private readonly quuz: string;
}

interface Point {
    readonly x: number;
    readonly y: number;
}
```

Note that some of the `readonly` modifiers do not receive highlighting.

This fixes that.

Let me know if you have any questions.