### PR TITLE
highlight unicode escapes in strings

### DIFF
--- a/syntax/basic/literal.vim
+++ b/syntax/basic/literal.vim
@@ -8,10 +8,13 @@ syntax region  typescriptTemplateSubstitution matchgroup=typescriptTemplateSB
   \ contains=@typescriptValue
   \ contained
 
-syntax region  typescriptString
-  \ start=/\z(["']\)/  skip=/\\\\\|\\\z1\|\\\n/  end=/\z1\|$/
-  \ nextgroup=@typescriptSymbols
-  \ skipwhite skipempty
+
+syntax region  typescriptString 
+  \ start=+\z(["']\)+  skip=+\\\%(\z1\|$\)+  end=+\z1+ end=+$+
+  \ contains=typescriptSpecial,@Spell
+  \ extend
+
+syntax match   typescriptSpecial            contained "\v\\%(x\x\x|u%(\x{4}|\{\x{4,5}})|c\u|.)"
 
 " From vim runtime
 " <https://github.com/vim/vim/blob/master/runtime/syntax/javascript.vim#L48>

--- a/syntax/common.vim
+++ b/syntax/common.vim
@@ -64,6 +64,7 @@ if exists("did_typescript_hilink")
   HiLink typescriptDocParamName         Type
   HiLink typescriptDocParamType         Type
   HiLink typescriptString               String
+  HiLink typescriptSpecial              Special
   HiLink typescriptStringLiteralType    String
   HiLink typescriptStringMember         String
   HiLink typescriptTemplate             String

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -483,3 +483,11 @@ Given typescript (template string in object):
   var a = { test: css`color: red` }
 Execute:
   AssertEqual 'typescriptTemplate', SyntaxAt(1, 20)
+
+Given typescript (unicode escape characters in strings):
+  const str = 'test\u200btest'
+Execute:
+  AssertEqual 'typescriptString', SyntaxAt(1, 17)
+  AssertEqual 'typescriptSpecial', SyntaxAt(1, 18)
+  AssertEqual 'typescriptString', SyntaxAt(1, 24)
+


### PR DESCRIPTION
This PR basically just cold-copies how strings are parsed in [vim-javascript](https://github.com/pangloss/vim-javascript).

In short, it adds the ability to highlight escape sequences in string literals.

This might also need to be added to template literals. Didn't check there.

Let me know if you need anything else.