### PR TITLE
refacotr: HiLink typescriptTestGlobal to Function

### DIFF
--- a/syntax/common.vim
+++ b/syntax/common.vim
@@ -73,7 +73,7 @@ if exists("did_typescript_hilink")
   HiLink typescriptTemplateSB           Label
   HiLink typescriptRegexpString         String
   HiLink typescriptGlobal               Constant
-  HiLink typescriptTestGlobal           Keyword
+  HiLink typescriptTestGlobal           Function
   HiLink typescriptPrototype            Type
   HiLink typescriptConditional          Conditional
   HiLink typescriptConditionalElse      Conditional


### PR DESCRIPTION
As discussed [here](https://github.com/HerringtonDarkholme/yats.vim/pull/120), change `HiLink` of `typescriptTestGlobal` from `Keyword` to `Function`