### PR TITLE
[fix] spread argument syntax support

### DIFF
--- a/syntax/basic/function.vim
+++ b/syntax/basic/function.vim
@@ -27,7 +27,7 @@ syntax match   typescriptArrowFuncDef          contained /({\_[^}]*}\(:\_[^)]\)\
 " matches `(a) =>` or `([a]) =>` or
 " `(
 "  a) =>`
-syntax match   typescriptArrowFuncDef          contained /(\(\_s*[a-zA-Z\$_\[]\_[^)]*\)*)\s*=>/
+syntax match   typescriptArrowFuncDef          contained /(\(\_s*[a-zA-Z\$_\[.]\_[^)]*\)*)\s*=>/
   \ contains=typescriptArrowFuncArg,typescriptArrowFunc
   \ nextgroup=@typescriptExpression,typescriptBlock
   \ skipwhite skipempty

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -496,3 +496,10 @@ Given typescript (decorator generics):
   class FooBar {}
 Execute:
   AssertEqual 'typescriptPredefinedType', SyntaxAt(1, 6)
+
+Given typescript (spread arguments in arrow function):
+  let a = (...a: any[]) => {}
+Execute:
+  AssertEqual 'typescriptParens', SyntaxAt(1, 9)
+  AssertEqual 'typescriptRestOrSpread', SyntaxAt(1, 10)
+  AssertEqual 'typescriptCall', SyntaxAt(1, 13)


### PR DESCRIPTION
This fixes the support for spread arguments in arrow function, ex: `(...a: any[]) => {}`