### PR TITLE
Execute normal command without mapping on indent function

### DIFF
--- a/indent/typescript.vim
+++ b/indent/typescript.vim
@@ -462,7 +462,7 @@ function! Fixedgq(lnum, count)
     if l:count > 1
         while l:count > 1
             let l:count -= 1
-            normal J
+            normal! J
         endwhile
     endif
 


### PR DESCRIPTION
Use `normal!` instead of `normal` to execute normal commands without
mappings on Fixedgq function. Fix broken `qg` in case the user has `J`
mapped to something else other than to join lines. `normal! J` will
always perform join lines regardless of any user mapping.