### PR TITLE
Avoid duplication of match_words in some cases.

### DIFF
--- a/ftplugin/tsx.vim
+++ b/ftplugin/tsx.vim
@@ -1,11 +1,11 @@
 " modified from mxw/vim-jsx from html.vim
-if exists("loaded_matchit")
+if exists("loaded_matchit") && !exists('b:tsx_match_words')
   let b:match_ignorecase = 0
-  let s:tsx_match_words = '(:),\[:\],{:},<:>,' .
+  let b:tsx_match_words = '(:),\[:\],{:},<:>,' .
         \ '<\@<=\([^/][^ \t>]*\)[^>]*\%(/\@<!>\|$\):<\@<=/\1>'
   let b:match_words = exists('b:match_words')
-    \ ? b:match_words . ',' . s:tsx_match_words
-    \ : s:tsx_match_words
+    \ ? b:match_words . ',' . b:tsx_match_words
+    \ : b:tsx_match_words
 endif
 
 set suffixesadd+=.tsx


### PR DESCRIPTION
In some cases the filetype is set multiple times and the code that sets b:match_words executes for each instance. This commit add a tsx_match_words existence precondition check, and fix the '%' command issue discussed here https://github.com/neovim/neovim/issues/9187 and https://github.com/chrisbra/matchit/issues/11.

For more information, please checkout the original PR to `vim-jsx` by @ivangeorgiew . https://github.com/mxw/vim-jsx/pull/177