### PR TITLE
Don't clobber `suffixesadd`

### DIFF
--- a/ftplugin/typescript.vim
+++ b/ftplugin/typescript.vim
@@ -32,7 +32,7 @@ endfunction
 set path+=./node_modules/**,node_modules/**
 set include=import\_s.\\zs[^'\"]*\\ze
 set includeexpr=TsIncludeExpr(v:fname)
-set suffixesadd=.ts
+set suffixesadd+=.ts
 
 "
 " TagBar


### PR DESCRIPTION
This line currently resets the `suffixesadd` which can have unintended consequences and break other plugins / user configuration. We should append to `suffixesadd` instead of setting it (which clobbers existing things).