### PR TITLE
Support TS 3.7 assertion functions

### DIFF
--- a/syntax/basic/type.vim
+++ b/syntax/basic/type.vim
@@ -50,7 +50,8 @@ syntax cluster typescriptPrimaryType contains=
   \ typescriptTupleType,
   \ typescriptTypeQuery,
   \ typescriptStringLiteralType,
-  \ typescriptReadonlyArrayKeyword
+  \ typescriptReadonlyArrayKeyword,
+  \ typescriptAssertType
 
 syntax region  typescriptStringLiteralType contained
   \ start=/\z(["']\)/  skip=/\\\\\|\\\z1\|\\\n/  end=/\z1\|$/
@@ -125,6 +126,10 @@ syntax keyword typescriptUserDefinedType is
   \ contained nextgroup=@typescriptType skipwhite skipempty
 
 syntax keyword typescriptTypeQuery typeof keyof
+  \ nextgroup=typescriptTypeReference
+  \ contained skipwhite skipnl
+
+syntax keyword typescriptAssertType asserts
   \ nextgroup=typescriptTypeReference
   \ contained skipwhite skipnl
 

--- a/syntax/common.vim
+++ b/syntax/common.vim
@@ -153,6 +153,7 @@ if exists("did_typescript_hilink")
   HiLink typescriptTypeReference         Identifier
   HiLink typescriptConstructor           Keyword
   HiLink typescriptDecorator             Special
+  HiLink typescriptAssertType            Keyword
 
   highlight link typeScript             NONE
 

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -511,3 +511,26 @@ Given typescript (multiline tuple type):
 Execute:
   AssertEqual 'typescriptComment', SyntaxAt(2, 8)
   AssertEqual 'typescriptPredefinedType', SyntaxAt(2, 18)
+
+Given typescript (assertion functions for nullish assertion):
+  function assert(cond: any): asserts cond {
+    if (!cond) throw new Error('oops!');
+  }
+Execute:
+  AssertEqual 'typescriptAssertType', SyntaxAt(1, 29)
+  AssertEqual 'typescriptTypeReference', SyntaxAt(1, 37)
+
+Given typescript (assertion functions for type assertion):
+  function assertString(v: any): asserts v is string {
+    if (typeof v !== 'stirng') throw new Error('oops!');
+  }
+Execute:
+  AssertEqual 'typescriptAssertType', SyntaxAt(1, 32)
+  AssertEqual 'typescriptUserDefinedType', SyntaxAt(1, 42)
+
+Given typescript (asserts keyword only in type is highlighted):
+  asserts('hello')
+  asserts += 1
+Execute:
+  AssertNotEqual 'typescriptAssertType', SyntaxAt(1, 1)
+  AssertNotEqual 'typescriptAssertType', SyntaxAt(2, 1)


### PR DESCRIPTION
Hi,

TypeScript 3.7 was released as stable version. It includes 'assertion function' new feature as described in release note:

https://devblogs.microsoft.com/typescript/announcing-typescript-3-7/#assertion-functions

I added syntax highlight support for this. `asserts` keyword and following `is` keyword get highlighted correctly by this PR.

- Before (current latest master branch)

![スクリーンショット 2019-11-06 11 53 55](https://user-images.githubusercontent.com/823277/68264522-6057a700-008c-11ea-84fc-32baf4f22208.png)

- After (this PR branch)

![スクリーンショット 2019-11-06 11 53 37](https://user-images.githubusercontent.com/823277/68264528-69e10f00-008c-11ea-928e-11436168212d.png)
