### PR TITLE
Fix ?. and ?? operators break highlighting

### DIFF
--- a/indent/typescript.vim
+++ b/indent/typescript.vim
@@ -65,8 +65,8 @@ let s:var_stmt = '^\s*var'
 let s:comma_first = '^\s*,'
 let s:comma_last = ',\s*$'
 
-let s:ternary = '^\s\+[?|:]'
-let s:ternary_q = '^\s\+?'
+let s:ternary = '^\s\+[?:]'
+let s:ternary_q = '^\s\+?[.?]\@!'
 
 " 2. Auxiliary Functions {{{1
 " ======================

--- a/syntax/basic/symbols.vim
+++ b/syntax/basic/symbols.vim
@@ -3,7 +3,7 @@ syntax match typescriptUnaryOp /[+\-~!]/
  \ nextgroup=@typescriptValue
  \ skipwhite
 
-syntax region typescriptTernary matchgroup=typescriptTernaryOp start=/?/ end=/:/ contained contains=@typescriptValue,@typescriptComments nextgroup=@typescriptValue skipwhite skipempty
+syntax region typescriptTernary matchgroup=typescriptTernaryOp start=/?[.?]\@!/ end=/:/ contained contains=@typescriptValue,@typescriptComments nextgroup=@typescriptValue skipwhite skipempty
 
 syntax match   typescriptAssign  /=/ nextgroup=@typescriptValue
   \ skipwhite skipempty


### PR DESCRIPTION
I found `?.` operator breaks syntax highlighting since this plugin assumes a ternary operator for `?` symbol. Here is an example failure case:

![スクリーンショット 2019-11-14 15 33 14](https://user-images.githubusercontent.com/823277/68832378-1dcd4480-06f4-11ea-8fe1-ade5cbc178cd.png)

After the line including `?.`, `try` and `finally` keywords are not highlighted.

I fixed this issue by checking `.` and `?` are not following just after `?` in syntax highlighting rule for ternary operator.

Now it works fine:

![スクリーンショット 2019-11-14 15 32 41](https://user-images.githubusercontent.com/823277/68832351-0db56500-06f4-11ea-99fc-e9334b0e9867.png)

