### PR TITLE
Highlight special characters in template string

### DIFF
--- a/syntax/basic/literal.vim
+++ b/syntax/basic/literal.vim
@@ -22,7 +22,7 @@ syntax region  typescriptRegexpString          start=+/[^/*]+me=e-1 skip=+\\\\\|
 
 syntax region  typescriptTemplate
   \ start=/`/  skip=/\\\\\|\\`\|\n/  end=/`\|$/
-  \ contains=typescriptTemplateSubstitution
+  \ contains=typescriptTemplateSubstitution,typescriptSpecial,@Spell
   \ nextgroup=@typescriptSymbols
   \ skipwhite skipempty
 

--- a/syntax/basic/literal.vim
+++ b/syntax/basic/literal.vim
@@ -14,7 +14,7 @@ syntax region  typescriptString
   \ contains=typescriptSpecial,@Spell
   \ extend
 
-syntax match   typescriptSpecial            contained "\v\\%(x\x\x|u%(\x{4}|\{\x{4,5}})|c\u|.)"
+syntax match   typescriptSpecial            contained "\v\\%(x\x\x|u%(\x{4}|\{\x{1,6}})|c\u|.)"
 
 " From vim runtime
 " <https://github.com/vim/vim/blob/master/runtime/syntax/javascript.vim#L48>

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -540,3 +540,15 @@ Given typescript (optional chaining):
 Execute:
   AssertEqual 'typescriptDotNotation', SyntaxAt(1, 5)
   AssertEqual 'typescriptDotNotation', SyntaxAt(1, 15)
+
+Given typescript (special characters in template string):
+  `nl\nbs\\bt\`foo`
+Execute:
+  AssertEqual 'typescriptTemplate', SyntaxAt(1, 1)
+  AssertEqual 'typescriptSpecial', SyntaxAt(1, 4)
+  AssertEqual 'typescriptTemplate', SyntaxAt(1, 6)
+  AssertEqual 'typescriptSpecial', SyntaxAt(1, 8)
+  AssertEqual 'typescriptTemplate', SyntaxAt(1, 10)
+  AssertEqual 'typescriptSpecial', SyntaxAt(1, 12)
+  AssertEqual 'typescriptTemplate', SyntaxAt(1, 14)
+  AssertEqual 'typescriptTemplate', SyntaxAt(1, 17)


### PR DESCRIPTION
This plugin highlights special characters such as `\n`, `\x1f2e` `\u{101f2e}` in `'...'` and `"..."` literals. Template string literals also can have special characters escaped with `\` as well.

```typescript
console.log(`nl\nbs\\bt\`f\u{1f2e}oo`)
```

This PR adds highlights for the special characters in template strings.

And I also find small mistake in highlight of `\u{X...}` character. Currently this plugin limits number of digits in `\u{...}` to 4 or 5, but actually it can be 1~6. Character with 6 digits is for UTF-32. (ref: [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))

```typescript
// OK 
console.log('\u{1}');
console.log('\u{10FFFF}');
```