### PR TITLE
Support ECMAScript private fields added from TS 3.8

### DIFF
--- a/syntax/basic/members.vim
+++ b/syntax/basic/members.vim
@@ -5,7 +5,7 @@ syntax keyword typescriptConstructor           contained constructor
 
 syntax cluster memberNextGroup contains=typescriptMemberOptionality,typescriptTypeAnnotation,@typescriptCallSignature
 
-syntax match typescriptMember /\K\k*/
+syntax match typescriptMember /#\?\K\k*/
   \ nextgroup=@memberNextGroup
   \ contained skipwhite
 

--- a/syntax/common.vim
+++ b/syntax/common.vim
@@ -11,6 +11,8 @@ if main_syntax == 'typescript' || main_syntax == 'typescriptreact'
   setlocal iskeyword+=$
   " syntax cluster htmlJavaScript                 contains=TOP
 endif
+" For private field added from TypeScript 3.8
+setlocal iskeyword+=#
 
 " lowest priority on least used feature
 syntax match   typescriptLabel                /[a-zA-Z_$]\k*:/he=e-1 contains=typescriptReserved nextgroup=@typescriptStatement skipwhite skipempty

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -613,3 +613,16 @@ Execute:
   AssertEqual 'typescriptSpecial', SyntaxAt(1, 12)
   AssertEqual 'typescriptTemplate', SyntaxAt(1, 14)
   AssertEqual 'typescriptTemplate', SyntaxAt(1, 17)
+
+Given typescript (private class instance field):
+  class C {
+    #abc = 10;
+    foo() {
+      this.#abc;
+    }
+  }
+Execute:
+  " At '#' in '#abc'
+  AssertEqual 'typescriptMember', SyntaxAt(2, 3)
+  " At 'c' in '#abc'
+  AssertEqual 'typescriptMember', SyntaxAt(2, 6)


### PR DESCRIPTION
ECMAScript private fields spec was implemented in TypeScript and released at v3.8 beta.

https://github.com/microsoft/TypeScript/issues/33925

```
class C {
    #foo = 10;
    bar = true;

    piyo() {
        return this.#foo;
    }
}
```

- Previously the private name field declaration `#foo` in `#foo = 10` was not highlighted. This PR adds highlight to it
- Now '#' is part of identifiers in TypeScript. So this PR adds it to `iskeyword` option. Vim can recognize `#foo` as one identifier by it.