### PR TITLE
Fix highlighting is broken on type-only import and export statements added at TS 3.8

### DIFF
--- a/syntax/basic/keyword.vim
+++ b/syntax/basic/keyword.vim
@@ -1,6 +1,11 @@
 "Import
-syntax keyword typescriptImport                from as import
+syntax keyword typescriptImport                from as
+syntax match typescriptImport                  /\<import\%(\s\+type\)\?\>/
 syntax keyword typescriptExport                export
+  \ nextgroup=typescriptExportType
+  \ skipwhite
+syntax match typescriptExportType              /\<type\s*{\@=/
+  \ contained skipwhite skipempty skipnl
 syntax keyword typescriptModule                namespace module
 
 "this

--- a/syntax/basic/keyword.vim
+++ b/syntax/basic/keyword.vim
@@ -1,6 +1,10 @@
 "Import
 syntax keyword typescriptImport                from as
-syntax match typescriptImport                  /\<import\%(\s\+type\)\?\>/
+syntax keyword typescriptImport                import
+  \ nextgroup=typescriptImportType
+  \ skipwhite
+syntax keyword typescriptImportType            type
+  \ contained
 syntax keyword typescriptExport                export
   \ nextgroup=typescriptExportType
   \ skipwhite

--- a/syntax/common.vim
+++ b/syntax/common.vim
@@ -103,6 +103,7 @@ if exists("did_typescript_hilink")
   HiLink typescriptImport               Special
   HiLink typescriptAmbientDeclaration   Special
   HiLink typescriptExport               Special
+  HiLink typescriptExportType           Special
   HiLink typescriptModule               Special
   HiLink typescriptTry                  Special
   HiLink typescriptExceptions           Special

--- a/syntax/common.vim
+++ b/syntax/common.vim
@@ -101,6 +101,7 @@ if exists("did_typescript_hilink")
   HiLink typescriptLabel                Label
   HiLink typescriptStringProperty       String
   HiLink typescriptImport               Special
+  HiLink typescriptImportType           Special
   HiLink typescriptAmbientDeclaration   Special
   HiLink typescriptExport               Special
   HiLink typescriptExportType           Special

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -626,3 +626,22 @@ Execute:
   AssertEqual 'typescriptMember', SyntaxAt(2, 3)
   " At 'c' in '#abc'
   AssertEqual 'typescriptMember', SyntaxAt(2, 6)
+
+Given typescript (type-only import and export statements):
+  import type Foo from "mod";
+  import type {Foo, Bar} from "mod";
+  export type {SomeThing};
+  type Foo = number;
+  export type Foo = number;
+Execute:
+  AssertEqual 'typescriptImport', SyntaxAt(1, 8)
+  AssertNotEqual 'typescriptAliasDeclaration', SyntaxAt(1, 13)
+  AssertEqual 'typescriptImport', SyntaxAt(2, 8)
+  AssertNotEqual 'typescriptAliasDeclaration', SyntaxAt(2, 13)
+  AssertEqual 'typescriptExportType', SyntaxAt(3, 8)
+  AssertNotEqual 'typescriptAliasDeclaration', SyntaxAt(3, 13)
+  " Check `type Foo = ...` and `export type Foo = ...` are not broken
+  AssertEqual 'typescriptAliasKeyword', SyntaxAt(4, 1)
+  AssertEqual 'typescriptAliasDeclaration', SyntaxAt(4, 6)
+  AssertEqual 'typescriptAliasKeyword', SyntaxAt(5, 8)
+  AssertEqual 'typescriptAliasDeclaration', SyntaxAt(5, 13)

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -634,9 +634,9 @@ Given typescript (type-only import and export statements):
   type Foo = number;
   export type Foo = number;
 Execute:
-  AssertEqual 'typescriptImport', SyntaxAt(1, 8)
+  AssertEqual 'typescriptImportType', SyntaxAt(1, 8)
   AssertNotEqual 'typescriptAliasDeclaration', SyntaxAt(1, 13)
-  AssertEqual 'typescriptImport', SyntaxAt(2, 8)
+  AssertEqual 'typescriptImportType', SyntaxAt(2, 8)
   AssertNotEqual 'typescriptAliasDeclaration', SyntaxAt(2, 13)
   AssertEqual 'typescriptExportType', SyntaxAt(3, 8)
   AssertNotEqual 'typescriptAliasDeclaration', SyntaxAt(3, 13)


### PR DESCRIPTION
From TS 3.8, type-only import/export syntax is available:

```typescript
import type { SomeThing } from "./some-module.js";

export type { SomeThing };
```

https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-beta/#type-only-imports-exports

This syntax breaks current highlighting as follows:

<img width="420" alt="スクリーンショット 2020-01-11 20 50 08" src="https://user-images.githubusercontent.com/823277/72203819-46837780-34b4-11ea-9814-4c21224ff252.png">

yats.vim recognizes `type` keyword as type alias statement. 

This PR fixes the type-only import/export statements. Now `type` in `import type` and `export type` is highlighted as part of import/export statements.

<img width="438" alt="スクリーンショット 2020-01-11 20 49 47" src="https://user-images.githubusercontent.com/823277/72203827-62871900-34b4-11ea-8795-aac2c773ffc2.png">
