### PR TITLE
Fix highlighting on ':' after regex literal

### DIFF
--- a/syntax/basic/literal.vim
+++ b/syntax/basic/literal.vim
@@ -18,7 +18,7 @@ syntax match   typescriptSpecial            contained "\v\\%(x\x\x|u%(\x{4}|\{\x
 
 " From vim runtime
 " <https://github.com/vim/vim/blob/master/runtime/syntax/javascript.vim#L48>
-syntax region  typescriptRegexpString          start=+/[^/*]+me=e-1 skip=+\\\\\|\\/+ end=+/[gimuy]\{0,5\}\s*$+ end=+/[gimuy]\{0,5\}\s*[;.,)\]}]+me=e-1 nextgroup=typescriptDotNotation oneline
+syntax region  typescriptRegexpString          start=+/[^/*]+me=e-1 skip=+\\\\\|\\/+ end=+/[gimuy]\{0,5\}\s*$+ end=+/[gimuy]\{0,5\}\s*[;.,)\]}:]+me=e-1 nextgroup=typescriptDotNotation oneline
 
 syntax region  typescriptTemplate
   \ start=/`/  skip=/\\\\\|\\`\|\n/  end=/`\|$/


### PR DESCRIPTION
Current yats.vim does not consider `:` after `/` of regex literals. This PR fixes the highlighting as follows:

Before:

![スクリーンショット 2020-01-28 20 21 02](https://user-images.githubusercontent.com/823277/73259750-ca0acb80-420b-11ea-9a0c-4a16f351dabc.png)

After:

![スクリーンショット 2020-01-28 20 20 32](https://user-images.githubusercontent.com/823277/73259762-d0994300-420b-11ea-9f82-428f2be037c7.png)
