### PR TITLE
Only format JavaScript comments

### DIFF
--- a/ftplugin/typescriptreact.vim
+++ b/ftplugin/typescriptreact.vim
@@ -8,6 +8,8 @@ if exists("loaded_matchit") && !exists('b:tsx_match_words')
     \ : b:tsx_match_words
 endif
 
+" Comment formatting
+setlocal comments=s1:/*,mb:*,ex:*/,://
 setlocal formatoptions-=t formatoptions+=croql
 
 set suffixesadd+=.tsx


### PR DESCRIPTION
This PR sets the comments variable so that comment formatting will only effect:
* `//`
* `/*`
* `*/`

This fixes the issue [brought up here](https://github.com/HerringtonDarkholme/yats.vim/issues/174) which was incorrectly formatting certain characters as comments.