### PR TITLE
Support @ts-ignore and @ts-expect-error magic comments

### DIFF
--- a/syntax/basic/doc.vim
+++ b/syntax/basic/doc.vim
@@ -5,8 +5,9 @@ syntax match   shellbang "^#!.*iojs\>"
 
 "JavaScript comments
 syntax keyword typescriptCommentTodo TODO FIXME XXX TBD
+syntax match typescriptMagicComment "@ts-\%(ignore\|expect-error\)\>"
 syntax match   typescriptLineComment "//.*"
-  \ contains=@Spell,typescriptCommentTodo,typescriptRef
+  \ contains=@Spell,typescriptCommentTodo,typescriptRef,typescriptMagicComment
 syntax region  typescriptComment
   \ start="/\*"  end="\*/"
   \ contains=@Spell,typescriptCommentTodo extend

--- a/syntax/common.vim
+++ b/syntax/common.vim
@@ -55,6 +55,7 @@ if exists("did_typescript_hilink")
   HiLink typescriptLineComment          Comment
   HiLink typescriptDocComment           Comment
   HiLink typescriptCommentTodo          Todo
+  HiLink typescriptMagicComment         SpecialComment
   HiLink typescriptRef                  Include
   HiLink typescriptDocNotation          SpecialComment
   HiLink typescriptDocTags              SpecialComment

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -653,3 +653,19 @@ Given typescript (multi-line union (issue 162)):
 Execute:
   AssertEqual 'typescriptUnion', SyntaxAt(3, 3)
   AssertEqual 'typescriptMember', SyntaxAt(3, 7)
+
+Given typescript (@ts-* magic comments):
+  // @ts-ignore
+  // @ts-ignore: ignore this
+  // @ts-expect-error
+  // @ts-expect-error: for some reasons
+  // @ts-not-magic
+Execute:
+  " Check @ts-ignore
+  AssertEqual 'typescriptMagicComment', SyntaxAt(1, 4)
+  AssertEqual 'typescriptMagicComment', SyntaxAt(2, 4)
+  " Check @ts-expect-error
+  AssertEqual 'typescriptMagicComment', SyntaxAt(3, 4)
+  AssertEqual 'typescriptMagicComment', SyntaxAt(4, 4)
+  " Starts with '@ts-' but not magic
+  AssertNotEqual 'typescriptMagicComment', SyntaxAt(5, 4)


### PR DESCRIPTION
TypeScript 2.6 introduced `@ts-ignore` magic comment and TypeScript 3.9 will introduce `@ts-expect-error`.

They have special meaning and will affect the compiler behavior though they are comments. So I think they should be highlighted as special as well as doc comments.

This PR highlights them with `SpecialComment` highlight group.