### PR TITLE
Fix note on setting `re=1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Config
 ----
 * `let g:yats_host_keyword = 1`: configure yats to highlight host specific keywords like `addEventListener`. Default is 1. Set it 0 to turn off highlighting.
 
-* Note: `set re=1` explicitly in your vimrc. Old regexp engine will incur performance issues for yats and old engine is usually turned on by other plugins.
+* Note: `set re=0` explicitly in your vimrc. Old regexp engine will incur performance issues for yats and old engine is usually turned on by other plugins.
 
 Credits
 -------


### PR DESCRIPTION
Per discussion from this issue: https://github.com/HerringtonDarkholme/yats.vim/issues/25, having `set re=1` in .vimrc causes performance issues.

The README should recommend setting `re=0`, not `re=1` to avoid these problems.