### PR TITLE
Fix number literals with 0b, 0o, 0x prefixes (fix #184)

### DIFF
--- a/syntax/basic/literal.vim
+++ b/syntax/basic/literal.vim
@@ -37,7 +37,7 @@ syntax region  typescriptArray matchgroup=typescriptBraces
 syntax match typescriptNumber /\<0[bB][01][01_]*\>/        nextgroup=@typescriptSymbols skipwhite skipempty
 syntax match typescriptNumber /\<0[oO][0-7][0-7_]*\>/       nextgroup=@typescriptSymbols skipwhite skipempty
 syntax match typescriptNumber /\<0[xX][0-9a-fA-F][0-9a-fA-F_]*\>/ nextgroup=@typescriptSymbols skipwhite skipempty
-syntax match typescriptNumber /\d[0-9_]*\.\d[0-9_]*\|\d[0-9_]*\|\.\d[0-9]*/
+syntax match typescriptNumber /\<\d[0-9_]*\.\d[0-9_]*\>\|\<\d[0-9_]*\>\|\.\d[0-9]*\>/
   \ nextgroup=typescriptExponent,@typescriptSymbols skipwhite skipempty
 syntax match typescriptExponent /[eE][+-]\=\d[0-9]*\>/
   \ nextgroup=@typescriptSymbols skipwhite skipempty contained

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -669,3 +669,12 @@ Execute:
   AssertEqual 'typescriptMagicComment', SyntaxAt(4, 4)
   " Starts with '@ts-' but not magic
   AssertNotEqual 'typescriptMagicComment', SyntaxAt(5, 4)
+
+Given typescript (number literals with prefixes (issue 184)):
+  0xc0ffee
+  0b101010
+  0o755644
+Execute:
+  AssertEqual 'typescriptNumber', SyntaxAt(1, 2)
+  AssertEqual 'typescriptNumber', SyntaxAt(2, 2)
+  AssertEqual 'typescriptNumber', SyntaxAt(3, 2)


### PR DESCRIPTION
Fixes #184 as follows:

<img width="578" alt="スクリーンショット 2020-05-12 10 38 05" src="https://user-images.githubusercontent.com/823277/81628841-b0009c00-943c-11ea-946a-642c85b6eba4.png">
