### PR TITLE
Fix highlighting number literal with exponent part

### DIFF
--- a/syntax/basic/literal.vim
+++ b/syntax/basic/literal.vim
@@ -37,5 +37,5 @@ syntax region  typescriptArray matchgroup=typescriptBraces
 syntax match typescriptNumber /\<0[bB][01][01_]*\>/        nextgroup=@typescriptSymbols skipwhite skipempty
 syntax match typescriptNumber /\<0[oO][0-7][0-7_]*\>/       nextgroup=@typescriptSymbols skipwhite skipempty
 syntax match typescriptNumber /\<0[xX][0-9a-fA-F][0-9a-fA-F_]*\>/ nextgroup=@typescriptSymbols skipwhite skipempty
-syntax match typescriptNumber /\<\%(\d[0-9_]*\%(\.\d[0-9_]*\)\=\|\.\d[0-9]*\)\%([eE][+-]\=\d[0-9_]*\)\=\>/
+syntax match typescriptNumber /\<\%(\d[0-9_]*\%(\.\d[0-9_]*\)\=\|\.\d[0-9_]*\)\%([eE][+-]\=\d[0-9_]*\)\=\>/
   \ nextgroup=typescriptSymbols skipwhite skipempty

--- a/syntax/basic/literal.vim
+++ b/syntax/basic/literal.vim
@@ -37,7 +37,5 @@ syntax region  typescriptArray matchgroup=typescriptBraces
 syntax match typescriptNumber /\<0[bB][01][01_]*\>/        nextgroup=@typescriptSymbols skipwhite skipempty
 syntax match typescriptNumber /\<0[oO][0-7][0-7_]*\>/       nextgroup=@typescriptSymbols skipwhite skipempty
 syntax match typescriptNumber /\<0[xX][0-9a-fA-F][0-9a-fA-F_]*\>/ nextgroup=@typescriptSymbols skipwhite skipempty
-syntax match typescriptNumber /\<\d[0-9_]*\.\d[0-9_]*\>\|\<\d[0-9_]*\>\|\.\d[0-9]*\>/
-  \ nextgroup=typescriptExponent,@typescriptSymbols skipwhite skipempty
-syntax match typescriptExponent /[eE][+-]\=\d[0-9]*\>/
-  \ nextgroup=@typescriptSymbols skipwhite skipempty contained
+syntax match typescriptNumber /\<\%(\d[0-9_]*\%(\.\d[0-9_]*\)\=\|\.\d[0-9]*\)\%([eE][+-]\=\d[0-9_]*\)\=\>/
+  \ nextgroup=typescriptSymbols skipwhite skipempty

--- a/syntax/common.vim
+++ b/syntax/common.vim
@@ -96,7 +96,6 @@ if exists("did_typescript_hilink")
   HiLink typescriptType                 Type
   HiLink typescriptNull                 Boolean
   HiLink typescriptNumber               Number
-  HiLink typescriptExponent             Number
   HiLink typescriptBoolean              Boolean
   HiLink typescriptObjectLabel          typescriptLabel
   HiLink typescriptLabel                Label

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -688,17 +688,51 @@ Given typescript (number literals without prefixes (PR 186)):
   0E4
   1e+1
   1e-1
+  1_2_3.4_5e6_7
 Execute:
-  AssertEqual 'typescriptNumber', SyntaxAt(1, 1) " 0
-  AssertEqual 'typescriptNumber', SyntaxAt(2, 1) " 1 in 123
-  AssertEqual 'typescriptNumber', SyntaxAt(2, 3) " 3 in 123
-  AssertEqual 'typescriptNumber', SyntaxAt(3, 1) " 1 in 1.2
-  AssertEqual 'typescriptNumber', SyntaxAt(3, 2) " . in 1.2
-  AssertEqual 'typescriptNumber', SyntaxAt(3, 3) " 2 in 1.2
-  AssertEqual 'typescriptNumber', SyntaxAt(4, 4) " e in 123e4
-  AssertEqual 'typescriptNumber', SyntaxAt(4, 5) " 4 in 123e4
-  AssertEqual 'typescriptNumber', SyntaxAt(5, 4) " e in 1.2e4
-  AssertEqual 'typescriptNumber', SyntaxAt(5, 5) " 4 in 1.2e4
-  AssertEqual 'typescriptNumber', SyntaxAt(6, 2) " E in 0E4
-  AssertEqual 'typescriptNumber', SyntaxAt(7, 3) " + in 1e+1
-  AssertEqual 'typescriptNumber', SyntaxAt(8, 3) " - in 1e-1
+  " 0
+  AssertEqual 'typescriptNumber', SyntaxAt(1, 1)
+
+  " 1 in 123
+  AssertEqual 'typescriptNumber', SyntaxAt(2, 1)
+  " 3 in 123
+  AssertEqual 'typescriptNumber', SyntaxAt(2, 3)
+
+  " 1 in 1.2
+  AssertEqual 'typescriptNumber', SyntaxAt(3, 1)
+  " . in 1.2
+  AssertEqual 'typescriptNumber', SyntaxAt(3, 2)
+  " 2 in 1.2
+  AssertEqual 'typescriptNumber', SyntaxAt(3, 3)
+
+  " e in 123e4
+  AssertEqual 'typescriptNumber', SyntaxAt(4, 4)
+  " 4 in 123e4
+  AssertEqual 'typescriptNumber', SyntaxAt(4, 5)
+
+  " e in 1.2e4
+  AssertEqual 'typescriptNumber', SyntaxAt(5, 4)
+  " 4 in 1.2e4
+  AssertEqual 'typescriptNumber', SyntaxAt(5, 5)
+
+  " E in 0E4
+  AssertEqual 'typescriptNumber', SyntaxAt(6, 2)
+
+  " + in 1e+1
+  AssertEqual 'typescriptNumber', SyntaxAt(7, 3)
+
+  " - in 1e-1
+  AssertEqual 'typescriptNumber', SyntaxAt(8, 3)
+
+  " 1 in 1_2_3.4_5e6_7
+  AssertEqual 'typescriptNumber', SyntaxAt(9, 1)
+  " 3 in 1_2_3.4_5e6_7
+  AssertEqual 'typescriptNumber', SyntaxAt(9, 5)
+  " 4 in 1_2_3.4_5e6_7
+  AssertEqual 'typescriptNumber', SyntaxAt(9, 7)
+  " 5 in 1_2_3.4_5e6_7
+  AssertEqual 'typescriptNumber', SyntaxAt(9, 9)
+  " 7 in 1_2_3.4_5e6_7
+  AssertEqual 'typescriptNumber', SyntaxAt(9, 11)
+  " 9 in 1_2_3.4_5e6_7
+  AssertEqual 'typescriptNumber', SyntaxAt(9, 13)

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -678,3 +678,27 @@ Execute:
   AssertEqual 'typescriptNumber', SyntaxAt(1, 2)
   AssertEqual 'typescriptNumber', SyntaxAt(2, 2)
   AssertEqual 'typescriptNumber', SyntaxAt(3, 2)
+
+Given typescript (number literals without prefixes (PR 186)):
+  0
+  123
+  1.2
+  123e4
+  1.2e4
+  0E4
+  1e+1
+  1e-1
+Execute:
+  AssertEqual 'typescriptNumber', SyntaxAt(1, 1) " 0
+  AssertEqual 'typescriptNumber', SyntaxAt(2, 1) " 1 in 123
+  AssertEqual 'typescriptNumber', SyntaxAt(2, 3) " 3 in 123
+  AssertEqual 'typescriptNumber', SyntaxAt(3, 1) " 1 in 1.2
+  AssertEqual 'typescriptNumber', SyntaxAt(3, 2) " . in 1.2
+  AssertEqual 'typescriptNumber', SyntaxAt(3, 3) " 2 in 1.2
+  AssertEqual 'typescriptNumber', SyntaxAt(4, 4) " e in 123e4
+  AssertEqual 'typescriptNumber', SyntaxAt(4, 5) " 4 in 123e4
+  AssertEqual 'typescriptNumber', SyntaxAt(5, 4) " e in 1.2e4
+  AssertEqual 'typescriptNumber', SyntaxAt(5, 5) " 4 in 1.2e4
+  AssertEqual 'typescriptNumber', SyntaxAt(6, 2) " E in 0E4
+  AssertEqual 'typescriptNumber', SyntaxAt(7, 3) " + in 1e+1
+  AssertEqual 'typescriptNumber', SyntaxAt(8, 3) " - in 1e-1


### PR DESCRIPTION
#185 introduced regression when highlighting number literals with exponent part. For example, `1e2` is not highlighted as `typescriptNumber`

This is because yats.vim now requires `\>` after fraction part of number literal (`1` in `1e2`), however it does not match when `e` is following.

This PR fixes it by merging `typescriptExponent` into `typescriptNumber`. Simply removing `\>` from `typescriptNumber` highlight definition reproduces #184 so we cannot do that. Now all number literals are highlighted correctly as follows:

<img width="642" alt="screenshot" src="https://user-images.githubusercontent.com/823277/81921021-f4df2b00-9614-11ea-9995-7c2d2b19fd7c.png">


