### PR TITLE
make typescriptTemplateSB a special char

### DIFF
--- a/syntax/common.vim
+++ b/syntax/common.vim
@@ -73,7 +73,7 @@ if exists("did_typescript_hilink")
   HiLink typescriptTemplate             String
   HiLink typescriptEventString          String
   HiLink typescriptASCII                Special
-  HiLink typescriptTemplateSB           Label
+  HiLink typescriptTemplateSB           Special
   HiLink typescriptRegexpString         String
   HiLink typescriptGlobal               Constant
   HiLink typescriptTestGlobal           Function


### PR DESCRIPTION
`typescriptTemplateSB` is a `Label` that links to `Statement` in most of colorschemes.

`Statement` is often a first suspect to be `italic`, i.e.:
![image](https://user-images.githubusercontent.com/1726487/83445593-8cce7880-a44d-11ea-9edb-61ca98aeec21.png)

❤️