### PR TITLE
Fix highlight for identifiers starting with 'function'

### DIFF
--- a/syntax/basic/function.vim
+++ b/syntax/basic/function.vim
@@ -50,7 +50,7 @@ syntax region  typescriptArrowFuncArg          contained start=/<\|(/ end=/\ze=>
 syntax region typescriptReturnAnnotation contained start=/:/ end=/{/me=e-1 contains=@typescriptType nextgroup=typescriptBlock
 
 
-syntax region typescriptFuncImpl contained start=/function/ end=/{/me=e-1
+syntax region typescriptFuncImpl contained start=/function\>/ end=/{/me=e-1
   \ contains=typescriptFuncKeyword
   \ nextgroup=typescriptBlock
 

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -736,3 +736,10 @@ Execute:
   AssertEqual 'typescriptNumber', SyntaxAt(9, 11)
   " 9 in 1_2_3.4_5e6_7
   AssertEqual 'typescriptNumber', SyntaxAt(9, 13)
+
+Given typescript (identifier starting with 'function'):
+  (functionName)
+  [functionName]
+Execute:
+  AssertEqual 'typescriptParenExp', SyntaxAt(1, 2)
+  AssertEqual 'typescriptArray', SyntaxAt(2, 2)


### PR DESCRIPTION
In current yats.vim, identifier starting with 'function', like 'functionName', breaks highlighting
when placed in parentheses (i.e. not in top level).

![yats-fix-funcimpl](https://user-images.githubusercontent.com/23283270/83625989-c4fdc480-a5cf-11ea-9438-2d02344afa22.PNG)

This PR fixes the problem by modifying start condition of 'typescriptFuncImpl' syntax.
I'm not certain that this is the best way to do because I'm not familiar to vimscript nor its highlighting system though...