### PR TITLE
Test improve

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.cmd       text eol=crlf

--- a/test/start
+++ b/test/start
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
+cd $(dirname "$0")
 vim -u vimrc -c 'Vader! ./*.vader'

--- a/test/start.cmd
+++ b/test/start.cmd
@@ -1,0 +1,3 @@
+@setlocal
+@cd "%~dp0"
+call vim -u vimrc -c "Vader! ./syntax.vader"

--- a/test/vimrc
+++ b/test/vimrc
@@ -1,6 +1,6 @@
 set nocompatible
 filetype off
-let &rtp = &rtp.','.expand('%:p:h').'/vader.vim'
-let &rtp = &rtp.','.expand('%:p:h:h')
+let &rtp = expand('%:p:h:h').','.&rtp
+let &rtp = expand('%:p:h').'/vader.vim,'.&rtp
 filetype plugin indent on
 syntax enable


### PR DESCRIPTION
* Executable script from other directory.
* Added `test\start.cmd` for windows.
* Fixed runtime path, because to prevent the vim original runtime loaded first.