### PR TITLE
Added readonly modifier to constructor parameter

### DIFF
--- a/syntax/basic/type.vim
+++ b/syntax/basic/type.vim
@@ -156,6 +156,7 @@ syntax match typescriptTypeAnnotation /:/
 syntax cluster typescriptParameterList contains=
   \ typescriptTypeAnnotation,
   \ typescriptAccessibilityModifier,
+  \ typescriptReadonlyModifier,
   \ typescriptOptionalMark,
   \ typescriptRestOrSpread,
   \ typescriptFuncComma,

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -372,12 +372,18 @@ Given typescript (readonly modifier):
   class A {
     readonly photos!: Array<string>
     abstract readonly photos?: Array<string>
+    constructor(readonly photos?: Array<string>) {}
+    constructor(protected readonly photos?: Array<string>) {}
   }
 Execute:
+  AssertEqual 'typescriptReadonlyModifier', SyntaxAt(2, 3)
   AssertEqual 'typescriptMember', SyntaxAt(2, 16)
   AssertEqual 'typescriptPredefinedType', SyntaxAt(2, 30)
+  AssertEqual 'typescriptReadonlyModifier', SyntaxAt(3, 12)
   AssertEqual 'typescriptMember', SyntaxAt(3, 21)
   AssertEqual 'typescriptPredefinedType', SyntaxAt(3, 37)
+  AssertEqual 'typescriptReadonlyModifier', SyntaxAt(4, 15)
+  AssertEqual 'typescriptReadonlyModifier', SyntaxAt(5, 25)
 
 Given typescript (basic switch case):
   switch (a) {


### PR DESCRIPTION
Added `readonly` modifier to [constructor parameter properties](https://www.typescriptlang.org/docs/handbook/classes.html#parameter-properties).