### PR TITLE
Fix wildcard match after =

### DIFF
--- a/indent/typescript.vim
+++ b/indent/typescript.vim
@@ -49,7 +49,7 @@ let s:skip_expr = "synIDattr(synID(line('.'),col('.'),1),'name') =~ '".s:syng_st
 let s:line_term = '\s*\%(\%(\/\/\).*\)\=$'
 
 " Regex that defines continuation lines, not including (, {, or [.
-let s:continuation_regex = '\%([\\*+/.:]\|\%(<%\)\@<![=-]\|\W[|&?]\|||\|&&\|[^=]=[^=].*,\)' . s:line_term
+let s:continuation_regex = '\%([\\*+/.:]\|\%(<%\)\@<![=-]\|\W[|&?]\|||\|&&\|[^=]=[^=]\)' . s:line_term
 
 " Regex that defines continuation lines.
 " TODO: this needs to deal with if ...: and so on

--- a/test/indent.vader
+++ b/test/indent.vader
@@ -1,0 +1,15 @@
+Given typescript (Correct indentation after equals):
+  function foo(
+    bar = 1,
+  ): {
+    return bar
+  }
+  const d = {
+    foo: `another=word`,
+    bar: true
+  };
+Do:
+  ggVG=
+Execute:
+  AssertEqual 'typescriptStatementKeyword', SyntaxAt(4, 3)
+  AssertEqual 'typescriptObjectLabel', SyntaxAt(8, 3)


### PR DESCRIPTION
I have narrowed down the source of the problem for #196 and #194 to the following regex, where `line_term` matches optional whitespace and comment:

https://github.com/HerringtonDarkholme/yats.vim/blob/e6f121561506f011d878855b66ca8116a46121ae/indent/typescript.vim#L52

Specifically the `[^=]=[^=].*,` phrase. This phrase requires a comma and removing the comma from the end of a problematic line does resolve the indentation problem. However, I don't think that's the fix - I think the `continuation_regex` variable matches lines that end prematurely. A line ending with `=` almost certainly ends prematurely, but a line that contains an equals and ends in a comma is not necessarily unfinished.

This PR removes the regex that matches the wildcard and the comma after the `=` in the continuation lines regex.

This fixes #194:

```typescript
const d = {
    foo: `another=word`,
    bar: true // indented correctly
};
```

This also fixes #196:

```typescript
function doThing(
  boop = 4,
): {
  return boop // indented correctly
}
```