### PR TITLE
Arrow Function improvement

### DIFF
--- a/syntax/basic/cluster.vim
+++ b/syntax/basic/cluster.vim
@@ -30,6 +30,7 @@ syntax cluster typescriptTopExpression
 syntax cluster typescriptExpression
   \ contains=@typescriptTopExpression,
   \ typescriptArrowFuncDef,
+  \ typescriptGenericArrowFuncDef,
   \ typescriptFuncImpl
 
 syntax cluster typescriptValue

--- a/syntax/basic/function.vim
+++ b/syntax/basic/function.vim
@@ -18,34 +18,40 @@ syntax match   typescriptFuncName              contained /\K\k*/
   \ nextgroup=@typescriptCallSignature
   \ skipwhite
 
-" destructuring ({ a: ee }) =>
-syntax match   typescriptArrowFuncDef          contained /(\(\s*\({\_[^}]*}\|\k\+\)\(:\_[^)]\)\?,\?\)\+)\s*=>/
-  \ contains=typescriptArrowFuncArg,typescriptArrowFunc
-  \ nextgroup=@typescriptExpression,typescriptBlock
-  \ skipwhite skipempty
+" a => ...
+syntax match   typescriptArrowFuncDef  /\K\k*\s*=>/me=e-2
+  \ contains=typescriptArrowFuncArg
+  \ nextgroup=typescriptArrowFunc
+  \ contained skipwhite skipempty extend
 
-" matches `(a) =>` or `([a]) =>` or
-" `(
-"  a) =>`
-syntax match   typescriptArrowFuncDef          contained /(\(\_s*[a-zA-Z\$_\[.]\_[^)]*\)*)\s*=>/
-  \ contains=typescriptArrowFuncArg,typescriptArrowFunc
-  \ nextgroup=@typescriptExpression,typescriptBlock
-  \ skipwhite skipempty
+" (a, {b}, [c], ...) => ...
+" TODO: arguments type contains recursively parens
+syntax region  typescriptArrowFuncDef matchgroup=typescriptParens
+  \ start=/(\ze\%(\_[^()]\+\|(\_[^()]*)\)*)\_s*=>/ end=/)\_s*=>/me=e-2
+  \ contains=typescriptArrowFuncArg,@typescriptParameterList,@typescriptComments
+  \ nextgroup=typescriptArrowFunc
+  \ contained skipwhite skipempty
 
-syntax match   typescriptArrowFuncDef          contained /\K\k*\s*=>/
-  \ contains=typescriptArrowFuncArg,typescriptArrowFunc
-  \ nextgroup=@typescriptExpression,typescriptBlock
-  \ skipwhite skipempty
+" (a, {b}, [c], ...): ... => ...
+" TODO: arguments type contains recursively parens
+syntax region  typescriptArrowFuncDef matchgroup=typescriptParens
+  \ start=/(\ze\%(\_[^()]\+\|(\_[^()]*)\)*)\_s*:/ end=/=>/me=s-1
+  \ contains=typescriptArrowFuncReturnAnnotation,typescriptArrowFuncArg,@typescriptParameterList,@typescriptComments
+  \ nextgroup=typescriptArrowFunc
+  \ contained skipwhite skipempty
 
-" TODO: optimize this pattern
-syntax region   typescriptArrowFuncDef          contained start=/(\_[^(^)]*):/ end=/=>/
-  \ contains=typescriptArrowFuncArg,typescriptArrowFunc,typescriptTypeAnnotation
-  \ nextgroup=@typescriptExpression,typescriptBlock
-  \ skipwhite skipempty keepend
+" TODO: return type contains parenthesized type
+syntax region  typescriptArrowFuncReturnAnnotation
+  \ matchgroup=typescriptParens start=/)\ze\_s*:/ end=/=>/me=s-1
+  \ contains=typescriptTypeAnnotation
+  \ contained
 
 syntax match   typescriptArrowFunc             /=>/
+  \ nextgroup=@typescriptExpression,typescriptBlock
+  \ skipwhite skipempty
+
 syntax match   typescriptArrowFuncArg          contained /\K\k*/
-syntax region  typescriptArrowFuncArg          contained start=/<\|(/ end=/\ze=>/ contains=@typescriptCallSignature
+  \ nextgroup=typescriptTypeAnnotation
 
 syntax region typescriptReturnAnnotation contained start=/:/ end=/{/me=e-1 contains=@typescriptType nextgroup=typescriptBlock
 

--- a/syntax/basic/function.vim
+++ b/syntax/basic/function.vim
@@ -1,5 +1,5 @@
 syntax keyword typescriptAsyncFuncKeyword      async
-  \ nextgroup=typescriptFuncKeyword,typescriptArrowFuncDef
+  \ nextgroup=typescriptFuncKeyword,typescriptArrowFuncDef,typescriptGenericArrowFuncDef
   \ skipwhite
 
 syntax keyword typescriptAsyncFuncKeyword      await
@@ -38,6 +38,13 @@ syntax region  typescriptArrowFuncDef matchgroup=typescriptParens
   \ start=/(\ze\%(\_[^()]\+\|(\_[^()]*)\)*)\_s*:/ end=/=>/me=s-1
   \ contains=typescriptArrowFuncReturnAnnotation,typescriptArrowFuncArg,@typescriptParameterList,@typescriptComments
   \ nextgroup=typescriptArrowFunc
+  \ contained skipwhite skipempty
+
+" <C, ...>
+syntax region  typescriptGenericArrowFuncDef matchgroup=typescriptTypeBrackets
+  \ start=/</ end=/>/
+  \ contains=typescriptTypeParameter
+  \ nextgroup=typescriptArrowFuncDef
   \ contained skipwhite skipempty
 
 " TODO: return type contains parenthesized type

--- a/syntax/basic/identifiers.vim
+++ b/syntax/basic/identifiers.vim
@@ -27,3 +27,41 @@ syntax region  typescriptParenExp              matchgroup=typescriptParens start
 syntax region  typescriptFuncCallArg           contained matchgroup=typescriptParens start=/(/ end=/)/ contains=@typescriptValue,@typescriptComments nextgroup=@typescriptSymbols,typescriptDotNotation skipwhite skipempty skipnl
 syntax region  typescriptEventFuncCallArg      contained matchgroup=typescriptParens start=/(/ end=/)/ contains=@typescriptEventExpression
 syntax region  typescriptEventString           contained start=/\z(["']\)/  skip=/\\\\\|\\\z1\|\\\n/  end=/\z1\|$/ contains=typescriptASCII,@events
+
+syntax cluster typescriptVariableDeclarations
+  \ contains=typescriptVariableDeclaration,@typescriptDestructurings
+
+syntax match typescriptVariableDeclaration /[A-Za-z_$]\k*/
+  \ nextgroup=typescriptTypeAnnotation,typescriptAssign
+  \ contained skipwhite skipempty
+
+syntax cluster typescriptDestructuredVariables contains=
+  \ typescriptRestOrSpread,
+  \ typescriptDestructuredVariable,
+  \ @typescriptDestructurings
+
+syntax match typescriptDestructuredVariable    /[A-Za-z_$]\k*/
+  \ nextgroup=typescriptDestructuredAs
+  \ contained skipwhite skipempty
+
+syntax match typescriptDestructuredAsVariable  /[A-Za-z_$]\k*/ contained
+
+syntax match typescriptDestructuredAs /:/
+  \ nextgroup=typescriptDestructuredAsVariable,@typescriptDestructurings
+  \ contained skipwhite skipempty
+
+syntax cluster typescriptDestructurings contains=
+  \ typescriptArrayDestructuring,
+  \ typescriptObjectDestructuring
+
+syntax region typescriptArrayDestructuring matchgroup=typescriptBraces
+  \ start=/\[/ end=/]/
+  \ contains=@typescriptDestructuredVariables,@typescriptComments
+  \ nextgroup=typescriptTypeAnnotation,typescriptAssign
+  \ contained skipwhite skipempty fold
+
+syntax region typescriptObjectDestructuring matchgroup=typescriptBraces
+  \ start=/{/ end=/}/
+  \ contains=@typescriptDestructuredVariables,@typescriptComments
+  \ nextgroup=typescriptTypeAnnotation,typescriptAssign
+  \ contained skipwhite skipempty fold

--- a/syntax/basic/identifiers.vim
+++ b/syntax/basic/identifiers.vim
@@ -28,6 +28,8 @@ syntax region  typescriptFuncCallArg           contained matchgroup=typescriptPa
 syntax region  typescriptEventFuncCallArg      contained matchgroup=typescriptParens start=/(/ end=/)/ contains=@typescriptEventExpression
 syntax region  typescriptEventString           contained start=/\z(["']\)/  skip=/\\\\\|\\\z1\|\\\n/  end=/\z1\|$/ contains=typescriptASCII,@events
 
+syntax region  typescriptDestructuringString   contained start=/\z(["']\)/  skip=/\\\\\|\\\z1\|\\\n/  end=/\z1\|$/ contains=typescriptASCII
+
 syntax cluster typescriptVariableDeclarations
   \ contains=typescriptVariableDeclaration,@typescriptDestructurings
 
@@ -62,6 +64,6 @@ syntax region typescriptArrayDestructuring matchgroup=typescriptBraces
 
 syntax region typescriptObjectDestructuring matchgroup=typescriptBraces
   \ start=/{/ end=/}/
-  \ contains=@typescriptDestructuredVariables,@typescriptComments
+  \ contains=typescriptDestructuringString,@typescriptDestructuredVariables,@typescriptComments
   \ nextgroup=typescriptTypeAnnotation,typescriptAssign
   \ contained skipwhite skipempty fold

--- a/syntax/basic/keyword.vim
+++ b/syntax/basic/keyword.vim
@@ -27,16 +27,50 @@ syntax keyword typescriptIdentifier            arguments this super
   \ nextgroup=@afterIdentifier
 
 syntax keyword typescriptVariable              let var
-  \ nextgroup=typescriptVariableDeclaration
-  \ skipwhite skipempty skipnl
+  \ nextgroup=@typescriptVariableDeclarations
+  \ skipwhite skipempty
 
 syntax keyword typescriptVariable const
-  \ nextgroup=typescriptEnum,typescriptVariableDeclaration
-  \ skipwhite
+  \ nextgroup=typescriptEnum,@typescriptVariableDeclarations
+  \ skipwhite skipempty
+
+syntax cluster typescriptVariableDeclarations
+  \ contains=typescriptVariableDeclaration,@typescriptDestructurings
 
 syntax match typescriptVariableDeclaration /[A-Za-z_$]\k*/
   \ nextgroup=typescriptTypeAnnotation,typescriptAssign
-  \ contained skipwhite skipempty skipnl
+  \ contained skipwhite skipempty
+
+syntax cluster typescriptDestructuredVariables contains=
+  \ typescriptRestOrSpread,
+  \ typescriptDestructuredVariable,
+  \ @typescriptDestructurings
+
+syntax match typescriptDestructuredVariable    /[A-Za-z_$]\k*/
+  \ nextgroup=typescriptDestructuredAs
+  \ contained skipwhite skipempty
+
+syntax match typescriptDestructuredAsVariable  /[A-Za-z_$]\k*/ contained
+
+syntax match typescriptDestructuredAs /:/
+  \ nextgroup=typescriptDestructuredAsVariable,@typescriptDestructurings
+  \ contained skipwhite skipempty
+
+syntax cluster typescriptDestructurings contains=
+  \ typescriptArrayDestructuring,
+  \ typescriptObjectDestructuring
+
+syntax region typescriptArrayDestructuring matchgroup=typescriptBraces
+  \ start=/\[/ end=/]/
+  \ contains=@typescriptDestructuredVariables,@typescriptComments
+  \ nextgroup=typescriptTypeAnnotation,typescriptAssign
+  \ contained skipwhite skipempty fold
+
+syntax region typescriptObjectDestructuring matchgroup=typescriptBraces
+  \ start=/{/ end=/}/
+  \ contains=@typescriptDestructuredVariables,@typescriptComments
+  \ nextgroup=typescriptTypeAnnotation,typescriptAssign
+  \ contained skipwhite skipempty fold
 
 syntax region typescriptEnum matchgroup=typescriptEnumKeyword start=/enum / end=/\ze{/
   \ nextgroup=typescriptBlock

--- a/syntax/basic/keyword.vim
+++ b/syntax/basic/keyword.vim
@@ -34,44 +34,6 @@ syntax keyword typescriptVariable const
   \ nextgroup=typescriptEnum,@typescriptVariableDeclarations
   \ skipwhite skipempty
 
-syntax cluster typescriptVariableDeclarations
-  \ contains=typescriptVariableDeclaration,@typescriptDestructurings
-
-syntax match typescriptVariableDeclaration /[A-Za-z_$]\k*/
-  \ nextgroup=typescriptTypeAnnotation,typescriptAssign
-  \ contained skipwhite skipempty
-
-syntax cluster typescriptDestructuredVariables contains=
-  \ typescriptRestOrSpread,
-  \ typescriptDestructuredVariable,
-  \ @typescriptDestructurings
-
-syntax match typescriptDestructuredVariable    /[A-Za-z_$]\k*/
-  \ nextgroup=typescriptDestructuredAs
-  \ contained skipwhite skipempty
-
-syntax match typescriptDestructuredAsVariable  /[A-Za-z_$]\k*/ contained
-
-syntax match typescriptDestructuredAs /:/
-  \ nextgroup=typescriptDestructuredAsVariable,@typescriptDestructurings
-  \ contained skipwhite skipempty
-
-syntax cluster typescriptDestructurings contains=
-  \ typescriptArrayDestructuring,
-  \ typescriptObjectDestructuring
-
-syntax region typescriptArrayDestructuring matchgroup=typescriptBraces
-  \ start=/\[/ end=/]/
-  \ contains=@typescriptDestructuredVariables,@typescriptComments
-  \ nextgroup=typescriptTypeAnnotation,typescriptAssign
-  \ contained skipwhite skipempty fold
-
-syntax region typescriptObjectDestructuring matchgroup=typescriptBraces
-  \ start=/{/ end=/}/
-  \ contains=@typescriptDestructuredVariables,@typescriptComments
-  \ nextgroup=typescriptTypeAnnotation,typescriptAssign
-  \ contained skipwhite skipempty fold
-
 syntax region typescriptEnum matchgroup=typescriptEnumKeyword start=/enum / end=/\ze{/
   \ nextgroup=typescriptBlock
   \ skipwhite

--- a/syntax/basic/type.vim
+++ b/syntax/basic/type.vim
@@ -113,16 +113,16 @@ syntax region typescriptGenericFunc matchgroup=typescriptTypeBrackets
   \ containedin=typescriptFunctionType
   \ contained skipwhite skipnl
 
-syntax region typescriptFuncType matchgroup=typescriptParens
-  \ start=/(/ end=/)\s*=>/me=e-2
-  \ contains=@typescriptParameterList
-  \ nextgroup=typescriptFuncTypeArrow
-  \ contained skipwhite skipnl oneline
-
-syntax match typescriptFuncTypeArrow /=>/
+" TODO: arguments type contains recursively parens
+syntax region  typescriptFuncType
+  \ matchgroup=typescriptParens start=/(\ze\%(\_[^()]\+\|(\_[^()]*)\)*)\_s*=>/
+  \ matchgroup=typescriptFuncTypeArrow end=/\%()\_s*\)\@<==>/
+  \ contains=@typescriptParameterList,@typescriptComments
   \ nextgroup=@typescriptType
-  \ containedin=typescriptFuncType
-  \ contained skipwhite skipnl
+  \ contained skipwhite skipempty
+
+syntax match   typescriptParens  /)\ze\_s*=>/
+  \ contained containedin=typescriptFuncType
 
 
 syntax keyword typescriptConstructorType new
@@ -157,6 +157,7 @@ syntax match typescriptTypeAnnotation /:/
   \ contained skipwhite skipnl
 
 syntax cluster typescriptParameterList contains=
+  \ @typescriptDestructurings,
   \ typescriptTypeAnnotation,
   \ typescriptAccessibilityModifier,
   \ typescriptReadonlyModifier,

--- a/syntax/common.vim
+++ b/syntax/common.vim
@@ -85,6 +85,7 @@ if exists("did_typescript_hilink")
   HiLink typescriptBranch               Conditional
   HiLink typescriptIdentifier           Structure
   HiLink typescriptVariable             Identifier
+  HiLink typescriptDestructuredVariable PreProc
   HiLink typescriptEnumKeyword          Identifier
   HiLink typescriptRepeat               Repeat
   HiLink typescriptForOperator          Repeat

--- a/syntax/common.vim
+++ b/syntax/common.vim
@@ -72,6 +72,7 @@ if exists("did_typescript_hilink")
   HiLink typescriptStringMember         String
   HiLink typescriptTemplate             String
   HiLink typescriptEventString          String
+  HiLink typescriptDestructuringString  String
   HiLink typescriptASCII                Special
   HiLink typescriptTemplateSB           Label
   HiLink typescriptRegexpString         String


### PR DESCRIPTION
Improvement to parse *Arrow Function*.

* Add `typescriptDestructurings` that parses *Object* or *Array* destructuring.
  * Referenced by `typescriptVariableDeclarations` and `typescriptParameterList`.
* Fix `typescriptArrowFuncDef` so that it can correctly parse *Object* or *Array* destructuring.
* Fix `typescriptFuncType` so that it can contained in *Return Type* of `typescriptArrowFuncDef`.

This can be parsed correctly.
```typescript
const func = <
  C extends Readonly<Partial<{ foo: any, bar: any[] }>>
>(
  { foo, bar: [ baz, { 'qu qux': quux } ] }: C
) : <T>(foobar: T) => () => { barbaz: T } => {
  const { a, b: [ c, d, ...e ] } = foo;
  let f, g, h;
  ({ f, x: [ g, ...h ] } = quux);
  return <T>( foobar: T, ...ququx: any[] ): ( ) => { barbaz: T } => ( ) => ( { barbaz: ququx[0] } );
};
```

### TODO

* Can not parse *Parenthesized Type* contained in *Return Type* of *Arrow Func Def*.

Ex.
```typescript
const F = (): ('foo' | 'bar') => { return 'foo' };
```