### PR TITLE
Support ternary operations inside object literals

### DIFF
--- a/syntax/basic/object.vim
+++ b/syntax/basic/object.vim
@@ -1,6 +1,6 @@
 syntax region  typescriptObjectLiteral         matchgroup=typescriptBraces
   \ start=/{/ end=/}/
-  \ contains=@typescriptComments,typescriptObjectLabel,typescriptStringProperty,typescriptComputedPropertyName,typescriptObjectAsyncKeyword
+  \ contains=@typescriptComments,typescriptObjectLabel,typescriptStringProperty,typescriptComputedPropertyName,typescriptObjectAsyncKeyword,typescriptTernary
   \ fold contained
 
 syntax keyword typescriptObjectAsyncKeyword async contained


### PR DESCRIPTION
Fixes this snippet which is valid typecript but currently makes everything else in the file typescriptTemplate:
```
const func = a => {
  return { a: b === 'test' ? `${val}` : 'test' }
}

this should not be typescriptTemplate
```