### PR TITLE
test: add return type to test source

### DIFF
--- a/test/indent.vader
+++ b/test/indent.vader
@@ -1,7 +1,7 @@
 Given typescript (Correct indentation after equals):
   function foo(
     bar = 1,
-  ): {
+  ): number {
     return bar
   }
   const d = {


### PR DESCRIPTION
Test *Correct indentation after equals* is failed, because target source is invalid.
Block `{ return bar }` is matched with the return type of `typescriptObjectType`.

Solution (This PR)
- Add a return type to function.

Another solution
- Remove a colon of return type annotation.
