### PR TITLE
function: fix arrow func def in expression paren

### DIFF
--- a/syntax/basic/function.vim
+++ b/syntax/basic/function.vim
@@ -18,27 +18,17 @@ syntax match   typescriptFuncName              contained /\K\k*/
   \ nextgroup=@typescriptCallSignature
   \ skipwhite
 
-" destructuring ({ a: ee }) =>
-syntax match   typescriptArrowFuncDef          contained /(\(\s*\({\_[^}]*}\|\k\+\)\(:\_[^)]\)\?,\?\)\+)\s*=>/
-  \ contains=typescriptArrowFuncArg,typescriptArrowFunc
-  \ nextgroup=@typescriptExpression,typescriptBlock
-  \ skipwhite skipempty
-
-" matches `(a) =>` or `([a]) =>` or
-" `(
-"  a) =>`
-syntax match   typescriptArrowFuncDef          contained /(\(\_s*[a-zA-Z\$_\[.]\_[^)]*\)*)\s*=>/
-  \ contains=typescriptArrowFuncArg,typescriptArrowFunc
-  \ nextgroup=@typescriptExpression,typescriptBlock
-  \ skipwhite skipempty
-
 syntax match   typescriptArrowFuncDef          contained /\K\k*\s*=>/
   \ contains=typescriptArrowFuncArg,typescriptArrowFunc
   \ nextgroup=@typescriptExpression,typescriptBlock
   \ skipwhite skipempty
 
-" TODO: optimize this pattern
-syntax region   typescriptArrowFuncDef          contained start=/(\_[^(^)]*):/ end=/=>/
+syntax match   typescriptArrowFuncDef          contained /(\%(\_[^()]\+\|(\_[^()]*)\)*)\_s*=>/
+  \ contains=typescriptArrowFuncArg,typescriptArrowFunc
+  \ nextgroup=@typescriptExpression,typescriptBlock
+  \ skipwhite skipempty
+
+syntax region  typescriptArrowFuncDef          contained start=/(\%(\_[^()]\+\|(\_[^()]*)\)*):/ end=/=>/
   \ contains=typescriptArrowFuncArg,typescriptArrowFunc,typescriptTypeAnnotation
   \ nextgroup=@typescriptExpression,typescriptBlock
   \ skipwhite skipempty keepend

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -453,8 +453,38 @@ Given typescript (high order arrow func in class):
     a = (a: () => void) => { }
   }
 Execute:
+  AssertEqual 'typescriptFuncTypeArrow', SyntaxAt(2, 14)
+  AssertEqual 'typescriptPredefinedType', SyntaxAt(2, 17)
   AssertEqual 'typescriptArrowFunc', SyntaxAt(2, 23)
 
+Given typescript (high order arrow func with return type in class):
+  class A {
+    a = (a: () => void): void => { }
+  }
+Execute:
+  AssertEqual 'typescriptFuncTypeArrow', SyntaxAt(2, 14)
+  AssertEqual 'typescriptPredefinedType', SyntaxAt(2, 17)
+  AssertEqual 'typescriptPredefinedType', SyntaxAt(2, 24)
+  AssertEqual 'typescriptArrowFunc', SyntaxAt(2, 29)
+
+Given typescript (assign arrow func in expression paren):
+  let a
+  const b = (a = () => void 0)
+  const c = 1
+Execute:
+  AssertEqual 'typescriptParenExp', SyntaxAt(2, 13)
+  AssertEqual 'typescriptArrowFunc', SyntaxAt(2, 19)
+  AssertEqual 'typescriptVariable', SyntaxAt(3, 1)
+
+Given typescript (assign arrow func with return type in expression paren):
+  let a
+  const b = (a = (): void => void 0)
+  const c = 1
+Execute:
+  AssertEqual 'typescriptParenExp', SyntaxAt(2, 13)
+  AssertEqual 'typescriptPredefinedType', SyntaxAt(2, 20)
+  AssertEqual 'typescriptArrowFunc', SyntaxAt(2, 25)
+  AssertEqual 'typescriptVariable', SyntaxAt(3, 1)
 
 Given typescript (line break after interface):
   interface A


### PR DESCRIPTION
Problem: Assignment of arrow func is broken in expression paren.

#### Before
![yats vim-arrowfunc-invalid](https://user-images.githubusercontent.com/22977/98331955-098b0180-2041-11eb-8cc6-1dbf4d92c67e.png)
#### Fixed
![yats vim-arrowfunc-fixed](https://user-images.githubusercontent.com/22977/98331965-0c85f200-2041-11eb-94a9-f9d6fdfac667.png)

## Implements

- Allow 1-level recursive paren in the arugments paren of the arrow function
- Simplify `typescriptArrowFuncDef`
  - Remove `({ a: ee }) =>`, `(a) =>` or `([a]) =>` destructuring, because it doesn't affect the decision

## Limitation

- Can not parse 2 or more level recursive parens

## Other

**high order arrow func with return type in class** is fixed too.
Previously it was only tested without a return type.