### PR TITLE
Fix The Bug Brought by #212

### DIFF
--- a/ftplugin/typescript.vim
+++ b/ftplugin/typescript.vim
@@ -16,7 +16,7 @@ setlocal commentstring=//\ %s
 setlocal formatoptions-=t formatoptions+=croql
 
 if !&l:formatexpr && !&l:formatprg
-    setlocal formatprg=Fixedgq(v:lnum,v:count)
+    setlocal formatexpr=Fixedgq(v:lnum,v:count)
 endif
 
 " setlocal foldmethod=syntax


### PR DESCRIPTION
In PR #212, there is a [bug that `Fixedgq` is used along with the `formatprg` option](https://github.com/HerringtonDarkholme/yats.vim/pull/212/files#diff-c68956a6bc49c23f0304a1e0cfcbd11ecf7840526017bae51907e70475d19631R19). According to the Vim/NeoVim doc

```
'formatprg' 'fp'	string (default "")
			global or local to buffer |global-local|

	The name of an external program that will be used to format the lines
	selected with the |gq| operator.  The program must take the input on
	stdin and produce the output on stdout.  The Unix program "fmt" is
	such a program.
```

this function should only be used in the `formatexpr` option.

c.c. #209 