### PR TITLE
Support highlighting key remapping in mapped type

### DIFF
--- a/syntax/basic/type.vim
+++ b/syntax/basic/type.vim
@@ -81,7 +81,7 @@ syntax region typescriptParenthesizedType matchgroup=typescriptParens
   \ contained skipwhite skipempty fold
 
 syntax match typescriptTypeReference /\K\k*\(\.\K\k*\)*/
-  \ nextgroup=typescriptTypeArguments,@typescriptTypeOperator,typescriptUserDefinedType
+  \ nextgroup=typescriptTypeArguments,@typescriptTypeOperator,typescriptUserDefinedType,typescriptCastKeyword
   \ skipwhite contained skipempty
 
 syntax keyword typescriptPredefinedType any number boolean string void never undefined null object unknown

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -909,3 +909,13 @@ Given typescript (ternary in objeect):
 Execute:
   AssertEqual 'typescriptTemplateSubstitution', SyntaxAt(2, 33)
   AssertEqual 'typescriptTemplateSB', SyntaxAt(2, 36)
+
+Given typescript (key mapping in mapped types):
+  type MappedTypeWithNewKeys<T> = {
+    [K in keyof T as NewKeyType]: T[K]
+  }
+Execute:
+  " 'a' at 'as' to check the keyword is highlighted
+  AssertEqual 'typescriptCastKeyword', SyntaxAt(2, 17)
+  " 'N' at 'NewKeyType' to check converted type is highlighted
+  AssertEqual 'typescriptTypeReference', SyntaxAt(2, 20)


### PR DESCRIPTION
TypeScript 4.1 introduced key remapping in mapped types:

```typescript
type MappedTypeWithNewKeys<T> = {
    [K in keyof T as NewKeyType]: T[K]
    //            ^^^^^^^^^^^^^
    //            This is the new syntax!
}
```

https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/#key-remapping-in-mapped-types

This PR adds syntax highlighting support for the feature:

### Before

<img width="321" alt="スクリーンショット 2020-11-20 22 45 10" src="https://user-images.githubusercontent.com/823277/99806945-17cd3780-2b82-11eb-9705-117ba8eddefc.png">

### After

<img width="323" alt="スクリーンショット 2020-11-20 22 44 52" src="https://user-images.githubusercontent.com/823277/99806966-1e5baf00-2b82-11eb-8077-3fb1e1e1053a.png">

On the current master branch, the `as` keyword and the succeeding converted type are highlighted as `typescriptNumber` incorrectly.