### PR TITLE
Better highlighting for key remapping in mapped types

### DIFF
--- a/syntax/basic/members.vim
+++ b/syntax/basic/members.vim
@@ -41,6 +41,6 @@ syntax region  typescriptStringMember   contained
 
 syntax region  typescriptComputedMember   contained matchgroup=typescriptProperty
   \ start=/\[/rs=s+1 end=/]/
-  \ contains=@typescriptValue,typescriptMember,typescriptMappedIn
+  \ contains=@typescriptValue,typescriptMember,typescriptMappedIn,typescriptCastKeyword
   \ nextgroup=@memberNextGroup
   \ skipwhite skipempty

--- a/syntax/basic/type.vim
+++ b/syntax/basic/type.vim
@@ -81,7 +81,7 @@ syntax region typescriptParenthesizedType matchgroup=typescriptParens
   \ contained skipwhite skipempty fold
 
 syntax match typescriptTypeReference /\K\k*\(\.\K\k*\)*/
-  \ nextgroup=typescriptTypeArguments,@typescriptTypeOperator,typescriptUserDefinedType,typescriptCastKeyword
+  \ nextgroup=typescriptTypeArguments,@typescriptTypeOperator,typescriptUserDefinedType
   \ skipwhite contained skipempty
 
 syntax keyword typescriptPredefinedType any number boolean string void never undefined null object unknown

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -910,12 +910,38 @@ Execute:
   AssertEqual 'typescriptTemplateSubstitution', SyntaxAt(2, 33)
   AssertEqual 'typescriptTemplateSB', SyntaxAt(2, 36)
 
-Given typescript (key mapping in mapped types):
-  type MappedTypeWithNewKeys<T> = {
+Given typescript (key remapping in mapped types):
+  type A<T> = {
     [K in keyof T as NewKeyType]: T[K]
-  }
+  };
+  type B<T, U> = {
+    [K in keyof SomeType<U> as NewKeyType]: T[K]
+  };
+  type B<T, X, Y, Z> = {
+    [K in keyof X | Y | Z as NewKeyType]: T[K]
+  };
+  type RemoveKindField<T> = {
+    [K in keyof T as Exclude<K, "kind">]: T[K]
+  };
+  type Getters<T> = {
+    [K in keyof T as `get${Capitalize<string & K>}`]: () => T[K]
+  };
 Execute:
   " 'a' at 'as' to check the keyword is highlighted
   AssertEqual 'typescriptCastKeyword', SyntaxAt(2, 17)
   " 'N' at 'NewKeyType' to check converted type is highlighted
   AssertEqual 'typescriptTypeReference', SyntaxAt(2, 20)
+  " A bit complicated type at operand of keyof
+  AssertEqual 'typescriptCastKeyword', SyntaxAt(5, 27)
+  AssertEqual 'typescriptTypeReference', SyntaxAt(5, 30)
+  " Union type at operand of keyof
+  AssertEqual 'typescriptCastKeyword', SyntaxAt(8, 25)
+  AssertEqual 'typescriptTypeReference', SyntaxAt(8, 28)
+  " Type modification at operand of 'as'
+  AssertEqual 'typescriptCastKeyword', SyntaxAt(11, 17)
+  AssertEqual 'typescriptTypeReference', SyntaxAt(11, 20)
+  AssertEqual 'typescriptStringLiteralType', SyntaxAt(11, 31)
+  " Template literal type at operand of 'as'
+  AssertEqual 'typescriptCastKeyword', SyntaxAt(14, 17)
+  AssertEqual 'typescriptTemplateLiteralType', SyntaxAt(14, 20)
+  AssertEqual 'typescriptTypeReference', SyntaxAt(14, 26)


### PR DESCRIPTION
After #220 had been merged, I tried more complicated cases and found that highlighting was broken in some cases when using key remapping in mapped types. This PR fixes the cases.

### Before

<img width="386" alt="スクリーンショット 2020-11-21 15 48 56" src="https://user-images.githubusercontent.com/823277/99869816-5d851100-2c11-11eb-8d2a-8a841ddc1665.png">

### After

<img width="386" alt="スクリーンショット 2020-11-21 15 49 14" src="https://user-images.githubusercontent.com/823277/99869823-6675e280-2c11-11eb-89ed-a263181c6b8a.png">

### Explanation

Previous implementation only considers that `as` is following type references like `T`, `T.U`. It means that more complicated types like `T<U>` are not considered. I reverted #220 implementation and added more suitable implementaiton.