### PR TITLE
Fix calling undefined functions

### DIFF
--- a/autoload/yats.vim
+++ b/autoload/yats.vim
@@ -6,7 +6,7 @@ let s:syng_linecom = 'linecomment\c'
 
 " Check if the character at lnum:col is inside a multi-line comment.
 function yats#IsInMultilineComment(lnum, col)
-  return !s:IsLineComment(a:lnum, a:col) && synIDattr(synID(a:lnum, a:col, 1), 'name') =~ s:syng_multiline
+  return !yats#IsLineComment(a:lnum, a:col) && synIDattr(synID(a:lnum, a:col, 1), 'name') =~ s:syng_multiline
 endfunction
 
 " Check if the character at lnum:col is a line comment.

--- a/indent/typescript.vim
+++ b/indent/typescript.vim
@@ -351,7 +351,7 @@ function GetTypescriptIndent()
   " If the line is empty and the previous nonblank line was a multi-line
   " comment, use that comment's indent. Deduct one char to account for the
   " space in ' */'.
-  if line =~ '^\s*$' && s:IsInMultilineComment(prevline, 1)
+  if line =~ '^\s*$' && yats#IsInMultilineComment(prevline, 1)
     return indent(prevline) - 1
   endif
 


### PR DESCRIPTION
I found some function calls cause undefined function errors. I guess they are mistakes on moving script-local functions to autoload functions (seem to be added by #212). This PR fixes them.