### PR TITLE
Refactor indent/typescriptreact.vim

### DIFF
--- a/indent/typescriptreact.vim
+++ b/indent/typescriptreact.vim
@@ -1,4 +1,5 @@
-exe 'runtime! indent/typescript.vim'
+runtime! indent/typescript.vim
+
 " Save the current JavaScript indentexpr.
 let b:tsx_ts_indentexpr = &indentexpr
 
@@ -7,7 +8,7 @@ if exists('b:did_indent')
   let s:did_indent=b:did_indent
   unlet b:did_indent
 endif
-exe 'runtime! indent/xml.vim'
+runtime! indent/xml.vim
 if exists('s:did_indent')
   let b:did_indent=s:did_indent
 endif

--- a/indent/typescriptreact.vim
+++ b/indent/typescriptreact.vim
@@ -20,6 +20,11 @@ setlocal indentkeys=0{,0},0),0],0\,,!^F,o,O,e
 " XML indentkeys
 setlocal indentkeys+=*<Return>,<>>,<<>,/
 
+" Only define the function once.
+if exists("*GetTsxIndent")
+  finish
+endif
+
 " Multiline end tag regex (line beginning with '>' or '/>')
 let s:endtag = '^\s*\/\?>\s*;\='
 let s:startexp = '[\{\(]\s*$'

--- a/indent/typescriptreact.vim
+++ b/indent/typescriptreact.vim
@@ -30,42 +30,42 @@ let s:endtag = '^\s*\/\?>\s*;\='
 let s:startexp = '[\{\(]\s*$'
 
 " Get all syntax types at the beginning of a given line.
-fu! SynSOL(lnum)
+fu! s:SynSOL(lnum)
   return map(synstack(a:lnum, 1), 'synIDattr(v:val, "name")')
 endfu
 
 " Get all syntax types at the end of a given line.
-fu! SynEOL(lnum)
+fu! s:SynEOL(lnum)
   let lnum = prevnonblank(a:lnum)
   let col = strlen(getline(lnum))
   return map(synstack(lnum, col), 'synIDattr(v:val, "name")')
 endfu
 
 " Check if a syntax attribute is XMLish.
-fu! SynAttrXMLish(synattr)
+fu! s:SynAttrXMLish(synattr)
   return a:synattr =~ "^xml" || a:synattr =~ "^tsx"
 endfu
 
 " Check if a synstack is XMLish (i.e., has an XMLish last attribute).
-fu! SynXMLish(syns)
-  return SynAttrXMLish(get(a:syns, -1))
+fu! s:SynXMLish(syns)
+  return s:SynAttrXMLish(get(a:syns, -1))
 endfu
 
 " Check if a synstack denotes the end of a TSX block.
-fu! SynTSXBlockEnd(syns)
+fu! s:SynTSXBlockEnd(syns)
   return get(a:syns, -1) =~ '\%(ts\|typescript\)Braces' &&
-       \ SynAttrXMLish(get(a:syns, -2))
+       \ s:SynAttrXMLish(get(a:syns, -2))
 endfu
 
 " Determine how many tsxRegions deep a synstack is.
-fu! SynTSXDepth(syns)
+fu! s:SynTSXDepth(syns)
   return len(filter(copy(a:syns), 'v:val ==# "tsxRegion"'))
 endfu
 
 " Check whether `cursyn' continues the same tsxRegion as `prevsyn'.
-fu! SynTSXContinues(cursyn, prevsyn)
-  let curdepth = SynTSXDepth(a:cursyn)
-  let prevdepth = SynTSXDepth(a:prevsyn)
+fu! s:SynTSXContinues(cursyn, prevsyn)
+  let curdepth = s:SynTSXDepth(a:cursyn)
+  let prevdepth = s:SynTSXDepth(a:prevsyn)
 
   " In most places, we expect the nesting depths to be the same between any
   " two consecutive positions within a tsxRegion (e.g., between a parent and
@@ -80,15 +80,15 @@ endfu
 
 " Cleverly mix JS and XML indentation.
 fu! GetTsxIndent()
-  let cursyn  = SynSOL(v:lnum)
-  let prevsyn = SynEOL(v:lnum - 1)
+  let cursyn  = s:SynSOL(v:lnum)
+  let prevsyn = s:SynEOL(v:lnum - 1)
 
   " Use XML indenting iff:
   "   - the syntax at the end of the previous line was either TSX or was the
   "     closing brace of a jsBlock whose parent syntax was TSX; and
   "   - the current line continues the same tsxRegion as the previous line.
-  if (SynXMLish(prevsyn) || SynTSXBlockEnd(prevsyn)) &&
-        \ SynTSXContinues(cursyn, prevsyn)
+  if (s:SynXMLish(prevsyn) || s:SynTSXBlockEnd(prevsyn)) &&
+        \ s:SynTSXContinues(cursyn, prevsyn)
     let ind = XmlIndentGet(v:lnum, 0)
     let l:line = getline(v:lnum)
     let l:pline = getline(v:lnum - 1)


### PR DESCRIPTION
This PR adds these small changes. Behavior should not be changed.

- Remove unnecessary `:execute`
- Do not define indent function if it is already existing. Current implementation redefines `GetTsxIndent()` repeatedly
- Prefer script-local functions. Unnecessary global functions should be avoided