### PR TITLE
syntax: fix `as` in braces

### DIFF
--- a/syntax/basic/identifiers.vim
+++ b/syntax/basic/identifiers.vim
@@ -18,13 +18,13 @@ syntax match   typescriptProp contained /\K\k*!\?/
   \ nextgroup=@afterIdentifier
   \ skipwhite skipempty
 
-syntax region  typescriptIndexExpr      contained matchgroup=typescriptProperty start=/\[/rs=s+1 end=/]/he=e-1 contains=@typescriptValue nextgroup=@typescriptSymbols,typescriptDotNotation,typescriptFuncCallArg skipwhite skipempty
+syntax region  typescriptIndexExpr      contained matchgroup=typescriptProperty start=/\[/rs=s+1 end=/]/he=e-1 contains=@typescriptValue,typescriptCastKeyword nextgroup=@typescriptSymbols,typescriptDotNotation,typescriptFuncCallArg skipwhite skipempty
 
 syntax match   typescriptDotNotation           /\.\|?\.\|!\./ nextgroup=typescriptProp skipnl
 syntax match   typescriptDotStyleNotation      /\.style\./ nextgroup=typescriptDOMStyle transparent
 " syntax match   typescriptFuncCall              contained /[a-zA-Z]\k*\ze(/ nextgroup=typescriptFuncCallArg
 syntax region  typescriptParenExp              matchgroup=typescriptParens start=/(/ end=/)/ contains=@typescriptComments,@typescriptValue,typescriptCastKeyword nextgroup=@typescriptSymbols skipwhite skipempty
-syntax region  typescriptFuncCallArg           contained matchgroup=typescriptParens start=/(/ end=/)/ contains=@typescriptValue,@typescriptComments nextgroup=@typescriptSymbols,typescriptDotNotation skipwhite skipempty skipnl
+syntax region  typescriptFuncCallArg           contained matchgroup=typescriptParens start=/(/ end=/)/ contains=@typescriptValue,@typescriptComments,typescriptCastKeyword nextgroup=@typescriptSymbols,typescriptDotNotation skipwhite skipempty skipnl
 syntax region  typescriptEventFuncCallArg      contained matchgroup=typescriptParens start=/(/ end=/)/ contains=@typescriptEventExpression
 syntax region  typescriptEventString           contained start=/\z(["']\)/  skip=/\\\\\|\\\z1\|\\\n/  end=/\z1\|$/ contains=typescriptASCII,@events
 

--- a/syntax/basic/literal.vim
+++ b/syntax/basic/literal.vim
@@ -5,7 +5,7 @@ syntax match   typescriptASCII                 contained /\\\d\d\d/
 
 syntax region  typescriptTemplateSubstitution matchgroup=typescriptTemplateSB
   \ start=/\${/ end=/}/
-  \ contains=@typescriptValue
+  \ contains=@typescriptValue,typescriptCastKeyword
   \ contained
 
 
@@ -29,7 +29,7 @@ syntax region  typescriptTemplate
 "Array
 syntax region  typescriptArray matchgroup=typescriptBraces
   \ start=/\[/ end=/]/
-  \ contains=@typescriptValue,@typescriptComments
+  \ contains=@typescriptValue,@typescriptComments,typescriptCastKeyword
   \ nextgroup=@typescriptSymbols,typescriptDotNotation
   \ skipwhite skipempty fold
 

--- a/syntax/basic/object.vim
+++ b/syntax/basic/object.vim
@@ -1,6 +1,6 @@
 syntax region  typescriptObjectLiteral         matchgroup=typescriptBraces
   \ start=/{/ end=/}/
-  \ contains=@typescriptComments,typescriptObjectLabel,typescriptStringProperty,typescriptComputedPropertyName,typescriptObjectAsyncKeyword,typescriptTernary
+  \ contains=@typescriptComments,typescriptObjectLabel,typescriptStringProperty,typescriptComputedPropertyName,typescriptObjectAsyncKeyword,typescriptTernary,typescriptCastKeyword
   \ fold contained
 
 syntax keyword typescriptObjectAsyncKeyword async contained

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -143,7 +143,74 @@ Execute:
 Given typescript (as in paren):
   (this as number)
 Execute:
-  AssertEqual 'typescriptPredefinedType', SyntaxAt(1, 12)
+  AssertEqual 'typescriptCastKeyword', SyntaxAt(1, 7)
+  AssertEqual 'typescriptPredefinedType', SyntaxAt(1, 10)
+
+Given typescript (as in function call arguments):
+  foo(this as number)
+Execute:
+  AssertEqual 'typescriptCastKeyword', SyntaxAt(1, 10)
+  AssertEqual 'typescriptPredefinedType', SyntaxAt(1, 13)
+
+Given typescript (as in array initialization):
+  const a = [this as number]
+Execute:
+  AssertEqual 'typescriptCastKeyword', SyntaxAt(1, 17)
+  AssertEqual 'typescriptPredefinedType', SyntaxAt(1, 20)
+
+Given typescript (as in object initialization):
+  const a = {a: 1 as number}
+Execute:
+  AssertEqual 'typescriptCastKeyword', SyntaxAt(1, 17)
+  AssertEqual 'typescriptPredefinedType', SyntaxAt(1, 20)
+
+Given typescript (as in property expression):
+  this["foo" as string]
+Execute:
+  AssertEqual 'typescriptCastKeyword', SyntaxAt(1, 12)
+  AssertEqual 'typescriptPredefinedType', SyntaxAt(1, 15)
+
+Given typescript (as in template substitution):
+  const a = `foo${1 as number}`
+Execute:
+  AssertEqual 'typescriptCastKeyword', SyntaxAt(1, 19)
+  AssertEqual 'typescriptPredefinedType', SyntaxAt(1, 22)
+
+Given typescript (as after number):
+  const a = 1 as number
+Execute:
+  AssertEqual 'typescriptCastKeyword', SyntaxAt(1, 13)
+  AssertEqual 'typescriptPredefinedType', SyntaxAt(1, 16)
+
+Given typescript (as after boolean):
+  const a = true as boolean
+Execute:
+  AssertEqual 'typescriptCastKeyword', SyntaxAt(1, 16)
+  AssertEqual 'typescriptPredefinedType', SyntaxAt(1, 19)
+
+Given typescript (as after string):
+  const a = "foo" as string
+Execute:
+  AssertEqual 'typescriptCastKeyword', SyntaxAt(1, 17)
+  AssertEqual 'typescriptPredefinedType', SyntaxAt(1, 20)
+
+Given typescript (as after paren):
+  const a = (a) as T
+Execute:
+  AssertEqual 'typescriptCastKeyword', SyntaxAt(1, 15)
+  AssertEqual 'typescriptTypeReference', SyntaxAt(1, 18)
+
+Given typescript (as after array):
+  const a = [a] as T
+Execute:
+  AssertEqual 'typescriptCastKeyword', SyntaxAt(1, 15)
+  AssertEqual 'typescriptTypeReference', SyntaxAt(1, 18)
+
+Given typescript (as after object):
+  const a = {a} as T
+Execute:
+  AssertEqual 'typescriptCastKeyword', SyntaxAt(1, 15)
+  AssertEqual 'typescriptTypeReference', SyntaxAt(1, 18)
 
 Given typescript (access property):
   const offset = abc[i]


### PR DESCRIPTION
The `as` below was not highlighted. Fix it.

```typescript
foo(this as number)
const a = [this as number]
const a = {a: 1 as number}
this["foo" as string]
const a = `foo${1 as number}`
```