### PR TITLE
Fix highlighting type annotation after colon

### DIFF
--- a/merged/typescript.vim
+++ b/merged/typescript.vim
@@ -236,7 +236,7 @@ syntax match   typescriptBinaryOp contained /-\(-\|=\)\?/ nextgroup=@typescriptV
 " 2: **, **=
 syntax match typescriptBinaryOp contained /\*\*=\?/ nextgroup=@typescriptValue
 
-syntax cluster typescriptSymbols               contains=typescriptBinaryOp,typescriptKeywordOp,typescriptTernary,typescriptAssign,typescriptCastKeyword
+syntax cluster typescriptSymbols               contains=typescriptBinaryOp,typescriptKeywordOp,typescriptTernary,typescriptAssign,typescriptCastKeyword,typescriptRestOrSpread,typescriptObjectSpread
 
 " runtime syntax/basic/reserved.vim
 "Import
@@ -589,7 +589,7 @@ syntax region typescriptCall matchgroup=typescriptParens
   \ nextgroup=typescriptTypeAnnotation,typescriptBlock
   \ contained skipwhite skipnl
 
-syntax match typescriptTypeAnnotation /:/
+syntax match typescriptTypeAnnotation /:\ze\s*[a-z]/
   \ nextgroup=@typescriptType
   \ contained skipwhite skipnl
 

--- a/syntax/basic/function.vim
+++ b/syntax/basic/function.vim
@@ -28,7 +28,7 @@ syntax match   typescriptArrowFuncDef          contained /(\%(\_[^()]\+\|(\_[^()
   \ nextgroup=@typescriptExpression,typescriptBlock
   \ skipwhite skipempty
 
-syntax region  typescriptArrowFuncDef          contained start=/(\%(\_[^()]\+\|(\_[^()]*)\)*):/ matchgroup=typescriptArrowFunc end=/=>/
+syntax region  typescriptArrowFuncDef          contained start=/(\%(\_[^()]\+\|(\_[^()]*)\)*):\s*\K/ matchgroup=typescriptArrowFunc end=/=>/
   \ contains=typescriptArrowFuncArg,typescriptTypeAnnotation,@typescriptCallSignature
   \ nextgroup=@typescriptExpression,typescriptBlock
   \ skipwhite skipempty keepend

--- a/syntax/basic/type.vim
+++ b/syntax/basic/type.vim
@@ -166,7 +166,7 @@ syntax region typescriptCall matchgroup=typescriptParens
   \ nextgroup=typescriptTypeAnnotation,typescriptBlock
   \ contained skipwhite skipnl
 
-syntax match typescriptTypeAnnotation /:/
+syntax match typescriptTypeAnnotation /:\ze\s*\K/
   \ nextgroup=@typescriptType
   \ contained skipwhite skipnl
 


### PR DESCRIPTION
The colon should only be interpreted as preceding a type annotation
if there is at least one keyword after some (optional) whitespace.

Otherwise a ternary like this would be improperly highlighted.

```jsx
  <div>
    {true ? (
      <div />
    ): (
      <span />
    )}
  </div>
```

Not sure if this breaks anything else though.