### PR TITLE
Highlight spread operator inside tsxEscJs

### DIFF
--- a/syntax/typescriptreact.vim
+++ b/syntax/typescriptreact.vim
@@ -113,7 +113,7 @@ syntax region tsxString contained start=+"+ end=+"+ contains=tsxEntity,@Spell di
 "          s~~~~~~~~~~~~~~e
 syntax region tsxEscJs
     \ contained
-    \ contains=@typescriptValue,@tsxComment
+    \ contains=@typescriptValue,@tsxComment,typescriptObjectSpread
     \ matchgroup=typescriptBraces
     \ start=+{+
     \ end=+}+


### PR DESCRIPTION
I think it's reasonable to highlight the spread operator:

```jsx
<div {...props} />
```