### PR TITLE
Fix tsxString only working for double quotes

### DIFF
--- a/syntax/typescriptreact.vim
+++ b/syntax/typescriptreact.vim
@@ -107,7 +107,7 @@ syntax match tsxEqual +=+ display contained
 
 " <tag id="sample">
 "         s~~~~~~e
-syntax region tsxString contained start=+"+ end=+"+ contains=tsxEntity,@Spell display
+syntax region tsxString contained start=+["']+ end=+["']+ contains=tsxEntity,@Spell display
 
 " <tag key={this.props.key}>
 "          s~~~~~~~~~~~~~~e


### PR DESCRIPTION
Please merge this one so single-quotes are also highlighted as a string in jsx.

```jsx
<div className='container' />
```