### PR TITLE
Fix parenthesized type not being highlighted inside arguments

### DIFF
--- a/syntax/basic/type.vim
+++ b/syntax/basic/type.vim
@@ -128,7 +128,7 @@ syntax region typescriptGenericFunc matchgroup=typescriptTypeBrackets
   \ contained skipwhite skipnl
 
 syntax region typescriptFuncType matchgroup=typescriptParens
-  \ start=/(/ end=/)\s*=>/me=e-2
+  \ start=/(\(\k\+:\|)\)\@=/ end=/)\s*=>/me=e-2
   \ contains=@typescriptParameterList
   \ nextgroup=typescriptFuncTypeArrow
   \ contained skipwhite skipnl oneline
@@ -137,7 +137,6 @@ syntax match typescriptFuncTypeArrow /=>/
   \ nextgroup=@typescriptType
   \ containedin=typescriptFuncType
   \ contained skipwhite skipnl
-
 
 syntax keyword typescriptConstructorType new
   \ nextgroup=@typescriptFunctionType

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -1061,3 +1061,22 @@ Execute:
   AssertEqual 'typescriptCastKeyword', SyntaxAt(14, 17)
   AssertEqual 'typescriptTemplateLiteralType', SyntaxAt(14, 20)
   AssertEqual 'typescriptTypeReference', SyntaxAt(14, 26)
+
+Given typescript (arrow function and parenthesized types inside function arguments):
+  export const fn = async (fn: (a: number, b: number) => number, arg: (T | U)[]) => {
+    const body = "isWrong"
+  }
+Execute:
+  " Arrow function inside function arguments
+  AssertEqual 'typescriptCall', SyntaxAt(1, 26)
+  AssertEqual 'typescriptFuncType', SyntaxAt(1, 31)
+  AssertEqual 'typescriptFuncType', SyntaxAt(1, 42)
+  AssertEqual 'typescriptFuncTypeArrow', SyntaxAt(1, 53)
+  " Types in parenthesis inside function arguments
+  AssertEqual 'typescriptTypeReference', SyntaxAt(1, 70)
+  AssertEqual 'typescriptUnion', SyntaxAt(1, 72)
+  AssertEqual 'typescriptTypeReference', SyntaxAt(1, 74)
+  " Function body
+  AssertEqual 'typescriptVariable', SyntaxAt(2, 3)
+  AssertEqual 'typescriptAssign', SyntaxAt(2, 14)
+  AssertEqual 'typescriptString', SyntaxAt(2, 16)


### PR DESCRIPTION
This happens because typescriptFuncType has precedence (it is declared
after). This just move typescriptParenthesizedType after so that is
takes precedence over arrow functions (which makes sense because they a
more specific end pattern).

Closes #233.