### PR TITLE
Fix typescript index expr region not ending

### DIFF
--- a/syntax/basic/identifiers.vim
+++ b/syntax/basic/identifiers.vim
@@ -18,7 +18,7 @@ syntax match   typescriptProp contained /\K\k*!\?/
   \ nextgroup=@afterIdentifier
   \ skipwhite skipempty
 
-syntax region  typescriptIndexExpr      contained matchgroup=typescriptProperty start=/\[/rs=s+1 end=/]/he=e-1 contains=@typescriptValue,typescriptCastKeyword nextgroup=@typescriptSymbols,typescriptDotNotation,typescriptFuncCallArg skipwhite skipempty
+syntax region  typescriptIndexExpr      contained matchgroup=typescriptProperty start=/\[/ end=/]/ contains=@typescriptValue,typescriptCastKeyword nextgroup=@typescriptSymbols,typescriptDotNotation,typescriptFuncCallArg skipwhite skipempty
 
 syntax match   typescriptDotNotation           /\.\|?\.\|!\./ nextgroup=typescriptProp skipnl
 syntax match   typescriptDotStyleNotation      /\.style\./ nextgroup=typescriptDOMStyle transparent

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -1080,3 +1080,9 @@ Execute:
   AssertEqual 'typescriptVariable', SyntaxAt(2, 3)
   AssertEqual 'typescriptAssign', SyntaxAt(2, 14)
   AssertEqual 'typescriptString', SyntaxAt(2, 16)
+
+Given typescript (expressions after property accessor with bracket notation):
+  a[0] || a
+Execute:
+  AssertEqual 'typescriptProperty', SyntaxAt(1, 2)
+  AssertEqual 'typescriptBinaryOp', SyntaxAt(1, 6)


### PR DESCRIPTION
It seems that the offsets are causing the problem

Taking this for example:

```typescript
const arr = [1, 2, 3]
console.log(arr[3] || 4)
```

The whole expression inside parenthesis would not be properly
highlighted. This fixes it.

Closes #232.