### PR TITLE
fix: Rename typescriptFuncArg highlight to typescriptFuncCallArg

### DIFF
--- a/merged/typescript.vim
+++ b/merged/typescript.vim
@@ -2210,7 +2210,7 @@ if exists("did_typescript_hilink")
   HiLink typescriptAsyncFunc            Keyword
   HiLink typescriptArrowFunc            Type
   HiLink typescriptFuncName             Function
-  HiLink typescriptFuncArg              PreProc
+  HiLink typescriptFuncCallArg          PreProc
   HiLink typescriptArrowFuncArg         PreProc
   HiLink typescriptFuncComma            Operator
 

--- a/merged/typescriptreact.vim
+++ b/merged/typescriptreact.vim
@@ -2305,7 +2305,7 @@ if exists("did_typescript_hilink")
   HiLink typescriptAsyncFunc            Keyword
   HiLink typescriptArrowFunc            Type
   HiLink typescriptFuncName             Function
-  HiLink typescriptFuncArg              PreProc
+  HiLink typescriptFuncCallArg          PreProc
   HiLink typescriptArrowFuncArg         PreProc
   HiLink typescriptFuncComma            Operator
 

--- a/syntax/common.vim
+++ b/syntax/common.vim
@@ -125,7 +125,7 @@ if exists("did_typescript_hilink")
   HiLink typescriptAsyncFunc            Keyword
   HiLink typescriptArrowFunc            Type
   HiLink typescriptFuncName             Function
-  HiLink typescriptFuncArg              PreProc
+  HiLink typescriptFuncCallArg          PreProc
   HiLink typescriptArrowFuncArg         PreProc
   HiLink typescriptFuncComma            Operator
 


### PR DESCRIPTION
`typescriptFuncArg` isn't a named syntax item; changing this `HiLink` to use `typescriptFunctionCallArg`.