### PR TITLE
feat: support highlighting `accessor` keyaord for auto accessor

### DIFF
--- a/syntax/common.vim
+++ b/syntax/common.vim
@@ -152,6 +152,7 @@ if exists("did_typescript_hilink")
   HiLink typescriptConstructorType       Function
   HiLink typescriptTypeQuery             Keyword
   HiLink typescriptAccessibilityModifier Keyword
+  HiLink typescriptAutoAccessor          Keyword
   HiLink typescriptOptionalMark          PreProc
   HiLink typescriptFuncType              Special
   HiLink typescriptMappedIn              Special

--- a/syntax/ts-common/members.vim
+++ b/syntax/ts-common/members.vim
@@ -16,6 +16,7 @@ syntax cluster typescriptPropertyMemberDeclaration contains=
   \ typescriptClassStatic,
   \ typescriptAccessibilityModifier,
   \ typescriptReadonlyModifier,
+  \ typescriptAutoAccessor,
   \ typescriptMethodAccessor,
   \ @typescriptMembers
   " \ typescriptMemberVariableDeclaration
@@ -33,6 +34,8 @@ syntax keyword typescriptClassStatic static
 syntax keyword typescriptAccessibilityModifier public private protected contained
 
 syntax keyword typescriptReadonlyModifier readonly override contained
+
+syntax keyword typescriptAutoAccessor accessor
 
 syntax region  typescriptStringMember   contained
   \ start=/\z(["']\)/  skip=/\\\\\|\\\z1\|\\\n/  end=/\z1/

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -1115,3 +1115,13 @@ Given typescript (backtick in Error):
   a = {b: Error(`${a}`)}
 Execute:
   AssertEqual 'typescriptBraces', SyntaxAt(1, 22)
+
+Given typescript (auto accessor):
+  class X {
+    accessor test = true;
+    @decolator accessor test2 = false;
+  }
+Execute:
+  AssertEqual 'typescriptAutoAccessor', SyntaxAt(2, 3)
+  AssertEqual 'typescriptDecorator', SyntaxAt(3, 3)
+  AssertEqual 'typescriptAutoAccessor', SyntaxAt(3, 14)


### PR DESCRIPTION
This PR adds highlighting support for [auto accessors in classes](https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/#auto-accessors-in-classes). The `accessor` keyword is a part of [Decorators proposal (stage3)](https://github.com/tc39/proposal-decorators) and TypeScript 4.9 added the support.

### Before

<img width="298" alt="image" src="https://github.com/HerringtonDarkholme/yats.vim/assets/823277/50da198e-45cd-466f-b7da-fd3712803bd3">

### After

<img width="299" alt="image" src="https://github.com/HerringtonDarkholme/yats.vim/assets/823277/9c324975-404c-4605-a9fa-1a53bb7cb88b">