### PR TITLE
fix: add missing `contained` to `typescriptAutoAccessor`

### DIFF
--- a/syntax/ts-common/members.vim
+++ b/syntax/ts-common/members.vim
@@ -35,7 +35,7 @@ syntax keyword typescriptAccessibilityModifier public private protected containe
 
 syntax keyword typescriptReadonlyModifier readonly override contained
 
-syntax keyword typescriptAutoAccessor accessor
+syntax keyword typescriptAutoAccessor accessor contained
 
 syntax region  typescriptStringMember   contained
   \ start=/\z(["']\)/  skip=/\\\\\|\\\z1\|\\\n/  end=/\z1/


### PR DESCRIPTION
I'm sorry that I missed `contained` at previous PR #266. This PR fixes it.