### PR TITLE
fix: fix syntax highlight for string literals in TSX element props

### DIFF
--- a/merged/typescriptreact.vim
+++ b/merged/typescriptreact.vim
@@ -107,7 +107,8 @@ syntax match tsxEqual +=+ display contained
 
 " <tag id="sample">
 "         s~~~~~~e
-syntax region tsxString contained start=+["']+ end=+["']+ contains=tsxEntity,@Spell display
+syntax region tsxString contained start=+"+ skip=+\\"+ end=+"+ contains=tsxEntity,@Spell display
+syntax region tsxString contained start=+'+ skip=+\\'+ end=+'+ contains=tsxEntity,@Spell display
 
 " <tag key={this.props.key}>
 "          s~~~~~~~~~~~~~~e

--- a/syntax/typescriptreact.vim
+++ b/syntax/typescriptreact.vim
@@ -107,7 +107,8 @@ syntax match tsxEqual +=+ display contained
 
 " <tag id="sample">
 "         s~~~~~~e
-syntax region tsxString contained start=+["']+ end=+["']+ contains=tsxEntity,@Spell display
+syntax region tsxString contained start=+"+ skip=+\\"+ end=+"+ contains=tsxEntity,@Spell display
+syntax region tsxString contained start=+'+ skip=+\\'+ end=+'+ contains=tsxEntity,@Spell display
 
 " <tag key={this.props.key}>
 "          s~~~~~~~~~~~~~~e

--- a/test/tsx.vader
+++ b/test/tsx.vader
@@ -104,6 +104,7 @@ Given typescriptreact (line comment in tsxRegion):
       }
       <h1>Hello World</h1>
       { // trailing brace is commented out }
+      }
     </div>
   )
 Execute:
@@ -141,3 +142,37 @@ Execute:
   AssertEqual 'tsxBlockComment', SyntaxAt(3, 9)
   AssertNotEqual 'tsxBlockComment', SyntaxAt(4, 0)
   AssertEqual 'tsxBlockComment', SyntaxAt(6, 9)
+
+Given typescriptreact (string literals in props):
+  const foo =
+    <Foo
+      singleQuote='test'
+      doubleQuote="test"
+      singleInDouble="'"
+      doubleInSingle='"'
+      escapedSingle='\''
+      escapedDouble="\""
+      otherProp={42}
+    >
+    </Foo>;
+Execute:
+  " Check 'test' and "test"
+  for line in [3, 4]
+    for col in range(17, 22)
+      AssertEqual 'tsxString', SyntaxAt(line, col)
+    endfor
+  endfor
+  " Check "'" and '"'
+  for line in [5, 6]
+    for col in range(20, 22)
+      AssertEqual 'tsxString', SyntaxAt(line, col)
+    endfor
+  endfor
+  " Check '\'' and "\""
+  for line in [7, 8]
+    for col in range(19, 22)
+      AssertEqual 'tsxString', SyntaxAt(line, col)
+    endfor
+  endfor
+  " Check if the string literal highlight terminated correctly
+  AssertEqual 'tsxAttrib', SyntaxAt(9, 5)


### PR DESCRIPTION
Fix #279

This PR fixes the following point:

- it didn't consider different quotes can be mixed in the content of string literals (e.g. single quote in double quote string literal)
- it didn't skip escaped quotes

Screenshots before/after this chagne:

| Before | After |
|-|-|
| <img width="322" alt="image" src="https://github.com/HerringtonDarkholme/yats.vim/assets/823277/7aefefd1-fa56-48a3-bc67-8eb383152c3e"> | <img width="319" alt="image" src="https://github.com/HerringtonDarkholme/yats.vim/assets/823277/a5c8625d-0cda-4468-aa80-0491e530d04b"> |
