### PR TITLE
ci: add GitHub Actions workflow for running syntax tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+on: [push, pull_request]
+
+env:
+  TERM: 'xterm'
+  DISPLAY: ':0.0'
+
+jobs:
+  vim:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: rhysd/action-setup-vim@v1
+        id: vim
+      - name: Run syntax tests on Vim
+        working-directory: test
+        run: |
+          ${{ steps.vim.outputs.executable }} -u vimrc -U NONE -i NONE -n -N -e -s -c 'Vader! syntax.vader tsx.vader'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,13 @@ on: [push, pull_request]
 
 env:
   TERM: 'xterm'
-  DISPLAY: ':0.0'
 
 jobs:
-  vim:
+  unit-tests:
+    strategy:
+      matrix:
+        editor: ['vim', 'neovim']
+      fail-fast: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -14,7 +17,9 @@ jobs:
           submodules: true
       - uses: rhysd/action-setup-vim@v1
         id: vim
-      - name: Run syntax tests on Vim
+        with:
+          neovim: ${{ matrix.editor == 'neovim' }}
+      - name: Run syntax tests
         working-directory: test
         run: |
           ${{ steps.vim.outputs.executable }} -u vimrc -U NONE -i NONE -n -N -e -s -c 'Vader! syntax.vader tsx.vader'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,0 @@
-script: cd ./test && ./start

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 YATS: Yet Another TypeScript Syntax
 ===================================
 
-[![Build Status](https://travis-ci.org/HerringtonDarkholme/yats.vim.svg?branch=master)](https://travis-ci.org/HerringtonDarkholme/yats.vim)
+[![Build Status](https://github.com/HerringtonDarkholme/yats.vim/actions/workflows/ci.yml/badge.svg)](https://github.com/HerringtonDarkholme/yats.vim/actions/workflows/ci.yml)
 
 ![screenshot](https://raw.githubusercontent.com/HerringtonDarkholme/yats.vim/master/screenshot.png)
 


### PR DESCRIPTION
This PR adds a CI workflow to run tests for syntax highlights. Tests for indentation were excluded because they're broken. I haven't looked into the failures, but `XmlIndentGet()` no longer seems to work as intended.

This PR does:

- Add new CI workflow for syntax tests on both Vim and Neovim
- Remove Travis CI stuff
- Update vader.vim submodule to the latest

Here is an example workflow run on my forked repository:

https://github.com/rhysd/yats.vim/actions/runs/9244704287