### PR TITLE
fix: set `b:undo=plugin` properly and set options locally in ftplugin

### DIFF
--- a/ftdetect/typescript.vim
+++ b/ftdetect/typescript.vim
@@ -1,3 +1,1 @@
-autocmd BufNewFile,BufRead *.ts setlocal filetype=typescript
-autocmd BufNewFile,BufRead *.cts setlocal filetype=typescript
-autocmd BufNewFile,BufRead *.mts setlocal filetype=typescript
+autocmd BufNewFile,BufRead *.ts,*.cts,*.mts setlocal filetype=typescript

--- a/ftdetect/typescriptreact.vim
+++ b/ftdetect/typescriptreact.vim
@@ -1,3 +1,1 @@
-autocmd BufNewFile,BufRead *.tsx setlocal filetype=typescriptreact
-autocmd BufNewFile,BufRead *.mtsx setlocal filetype=typescriptreact
-autocmd BufNewFile,BufRead *.ctsx setlocal filetype=typescriptreact
+autocmd BufNewFile,BufRead *.tsx,*mtsx,*ctsx setlocal filetype=typescriptreact

--- a/ftplugin/typescript.vim
+++ b/ftplugin/typescript.vim
@@ -15,8 +15,11 @@ setlocal commentstring=//\ %s
 " " and insert the comment leader when hitting <CR> or using "o".
 setlocal formatoptions-=t formatoptions+=croql
 
+let b:undo_ftplugin = 'setl fo< cms<'
+
 if !&l:formatexpr && !&l:formatprg
     setlocal formatexpr=Fixedgq(v:lnum,v:count)
+    let b:undo_ftplugin .= ' fex<'
 endif
 
 " setlocal foldmethod=syntax
@@ -98,6 +101,8 @@ set path+=./node_modules/**,node_modules/**
 set include=import\_s.\\zs[^'\"]*\\ze
 set includeexpr=TsIncludeExpr(v:fname)
 set suffixesadd+=.ts
+
+let b:undo_ftplugin .= ' pa< inc< inex< fex<'
 
 "
 " TagBar

--- a/ftplugin/typescript.vim
+++ b/ftplugin/typescript.vim
@@ -97,10 +97,10 @@ function! TsIncludeExpr(file)
   endif
 endfunction
 
-set path+=./node_modules/**,node_modules/**
-set include=import\_s.\\zs[^'\"]*\\ze
-set includeexpr=TsIncludeExpr(v:fname)
-set suffixesadd+=.ts
+setlocal path+=./node_modules/**,node_modules/**
+setlocal include=import\_s.\\zs[^'\"]*\\ze
+setlocal includeexpr=TsIncludeExpr(v:fname)
+setlocal suffixesadd+=.ts
 
 let b:undo_ftplugin .= ' pa< inc< inex< fex<'
 

--- a/ftplugin/typescript.vim
+++ b/ftplugin/typescript.vim
@@ -18,8 +18,8 @@ setlocal formatoptions-=t formatoptions+=croql
 let b:undo_ftplugin = 'setl fo< cms<'
 
 if !&l:formatexpr && !&l:formatprg
-    setlocal formatexpr=Fixedgq(v:lnum,v:count)
-    let b:undo_ftplugin .= ' fex<'
+  setlocal formatexpr=Fixedgq(v:lnum,v:count)
+  let b:undo_ftplugin .= ' fex<'
 endif
 
 " setlocal foldmethod=syntax
@@ -28,64 +28,64 @@ let &cpo = s:cpo_save
 unlet s:cpo_save
 
 function! Fixedgq(lnum, count)
-    let l:tw = &tw ? &tw : 80
+  let l:tw = &tw ? &tw : 80
 
-    let l:count = a:count
-    let l:first_char = indent(a:lnum) + 1
+  let l:count = a:count
+  let l:first_char = indent(a:lnum) + 1
 
-    if mode() == 'i' " gq was not pressed, but tw was set
-        return 1
-    endif
+  if mode() == 'i' " gq was not pressed, but tw was set
+    return 1
+  endif
 
-    " This gq is only meant to do code with strings, not comments
-    if yats#IsLineComment(a:lnum, l:first_char) || yats#IsInMultilineComment(a:lnum, l:first_char)
-        return 1
-    endif
+  " This gq is only meant to do code with strings, not comments
+  if yats#IsLineComment(a:lnum, l:first_char) || yats#IsInMultilineComment(a:lnum, l:first_char)
+    return 1
+  endif
 
-    if len(getline(a:lnum)) < l:tw && l:count == 1 " No need for gq
-        return 1
-    endif
+  if len(getline(a:lnum)) < l:tw && l:count == 1 " No need for gq
+    return 1
+  endif
 
-    " Put all the lines on one line and do normal splitting after that
-    if l:count > 1
-        while l:count > 1
-            let l:count -= 1
-            normal! J
-        endwhile
-    endif
+  " Put all the lines on one line and do normal splitting after that
+  if l:count > 1
+    while l:count > 1
+      let l:count -= 1
+      normal! J
+    endwhile
+  endif
 
-    let l:winview = winsaveview()
+  let l:winview = winsaveview()
 
+  call cursor(a:lnum, l:tw + 1)
+  let orig_breakpoint = searchpairpos(' ', '', '\.', 'bcW', '', a:lnum)
+  call cursor(a:lnum, l:tw + 1)
+  let breakpoint = searchpairpos(' ', '', '\.', 'bcW', s:skip_expr, a:lnum)
+
+  " No need for special treatment, normal gq handles edgecases better
+  if breakpoint[1] == orig_breakpoint[1]
+    call winrestview(l:winview)
+    return 1
+  endif
+
+  " Try breaking after string
+  if breakpoint[1] <= indent(a:lnum)
     call cursor(a:lnum, l:tw + 1)
-    let orig_breakpoint = searchpairpos(' ', '', '\.', 'bcW', '', a:lnum)
-    call cursor(a:lnum, l:tw + 1)
-    let breakpoint = searchpairpos(' ', '', '\.', 'bcW', s:skip_expr, a:lnum)
-
-    " No need for special treatment, normal gq handles edgecases better
-    if breakpoint[1] == orig_breakpoint[1]
-        call winrestview(l:winview)
-        return 1
-    endif
-
-    " Try breaking after string
-    if breakpoint[1] <= indent(a:lnum)
-        call cursor(a:lnum, l:tw + 1)
-        let breakpoint = searchpairpos('\.', '', ' ', 'cW', s:skip_expr, a:lnum)
-    endif
+    let breakpoint = searchpairpos('\.', '', ' ', 'cW', s:skip_expr, a:lnum)
+  endif
 
 
-    if breakpoint[1] != 0
-        call feedkeys("r\<CR>")
-    else
-        let l:count = l:count - 1
-    endif
+  if breakpoint[1] != 0
+    call feedkeys("r\<CR>")
+  else
+    let l:count = l:count - 1
+  endif
 
-    " run gq on new lines
-    if l:count == 1
-        call feedkeys("gqq")
-    endif
+  " run gq on new lines
+  if l:count == 1
+    call feedkeys("gqq")
+  endif
 
-    return 0
+  return 0
 endfunction
 
 function! TsIncludeExpr(file)

--- a/ftplugin/typescriptreact.vim
+++ b/ftplugin/typescriptreact.vim
@@ -1,3 +1,11 @@
+" Comment formatting
+setlocal comments=s1:/*,mb:*,ex:*/,://
+setlocal formatoptions-=t formatoptions+=croql
+
+setlocal suffixesadd+=.tsx
+
+let b:undo_ftplugin = 'setl fo< cms< sua<'
+
 " modified from mxw/vim-jsx from html.vim
 if exists("loaded_matchit") && !exists('b:tsx_match_words')
   let b:match_ignorecase = 0
@@ -6,10 +14,6 @@ if exists("loaded_matchit") && !exists('b:tsx_match_words')
   let b:match_words = exists('b:match_words')
     \ ? b:match_words . ',' . b:tsx_match_words
     \ : b:tsx_match_words
+
+  let b:undo_ftplugin .= ' | unlet! b:match_words b:match_ignorecase b:tsx_match_words'
 endif
-
-" Comment formatting
-setlocal comments=s1:/*,mb:*,ex:*/,://
-setlocal formatoptions-=t formatoptions+=croql
-
-set suffixesadd+=.tsx


### PR DESCRIPTION
This PR contains the following fixes and cleanups:

- Set `b:undo_ftplugin`. This is used when a user changes a file type with `:setfiletype`. Vim does clean up options set by a previous file type plugin before loading a new file type plugin.
- Use `:setlocal` instead of `:set` so that those option changes don't affect other buffers globally.
- ftplugin/typescript.vim mixes 2-spaces and 4-spaces indentations. Use 2-spaces indentation persistently.
- `:autocmd`s in ftdetect are a bit redundant. Use a single `:autocmd` to match multiple patterns.