### PR TITLE
Fix highlighting for certain keywords

### DIFF
--- a/merged/typescript.vim
+++ b/merged/typescript.vim
@@ -2048,7 +2048,7 @@ hi def link typescriptCase                  Conditional
 hi def link typescriptDefault               typescriptCase
 hi def link typescriptBranch                Conditional
 hi def link typescriptIdentifier            Structure
-hi def link typescriptVariable              Identifier
+hi def link typescriptVariable              Keyword
 hi def link typescriptUsing                 Identifier
 hi def link typescriptDestructureVariable   PreProc
 hi def link typescriptEnumKeyword           Identifier
@@ -2056,8 +2056,8 @@ hi def link typescriptRepeat                Repeat
 hi def link typescriptForOperator           Repeat
 hi def link typescriptStatementKeyword      Statement
 hi def link typescriptMessage               Keyword
-hi def link typescriptOperator              Identifier
-hi def link typescriptKeywordOp             Identifier
+hi def link typescriptOperator              Operator
+hi def link typescriptKeywordOp             Operator
 hi def link typescriptCastKeyword           Special
 hi def link typescriptType                  Type
 hi def link typescriptNull                  Boolean
@@ -2068,14 +2068,14 @@ hi def link typescriptDestructureLabel      Function
 hi def link typescriptLabel                 Label
 hi def link typescriptTupleLable            Label
 hi def link typescriptStringProperty        String
-hi def link typescriptImport                Special
+hi def link typescriptImport                Keyword
 hi def link typescriptImportType            Special
 hi def link typescriptAmbientDeclaration    Special
 hi def link typescriptExport                Special
 hi def link typescriptExportType            Special
 hi def link typescriptModule                Special
-hi def link typescriptTry                   Special
-hi def link typescriptExceptions            Special
+hi def link typescriptTry                   Exception
+hi def link typescriptExceptions            Exception
 
 hi def link typescriptMember                Function
 hi def link typescriptMethodAccessor        Operator

--- a/merged/typescript.vim
+++ b/merged/typescript.vim
@@ -2071,7 +2071,7 @@ hi def link typescriptStringProperty        String
 hi def link typescriptImport                Keyword
 hi def link typescriptImportType            Special
 hi def link typescriptAmbientDeclaration    Special
-hi def link typescriptExport                Special
+hi def link typescriptExport                Keyword
 hi def link typescriptExportType            Special
 hi def link typescriptModule                Special
 hi def link typescriptTry                   Exception
@@ -2098,7 +2098,7 @@ hi def link typescriptAbstract              Special
 " hi def link typescriptClassHeritage         Function
 " hi def link typescriptInterfaceHeritage     Function
 hi def link typescriptClassStatic           StorageClass
-hi def link typescriptReadonlyModifier      Keyword
+hi def link typescriptReadonlyModifier      StorageClass
 hi def link typescriptInterfaceKeyword      Keyword
 hi def link typescriptInterfaceExtends      Keyword
 hi def link typescriptInterfaceName         Function

--- a/merged/typescriptreact.vim
+++ b/merged/typescriptreact.vim
@@ -2167,7 +2167,7 @@ hi def link typescriptStringProperty        String
 hi def link typescriptImport                Keyword
 hi def link typescriptImportType            Special
 hi def link typescriptAmbientDeclaration    Special
-hi def link typescriptExport                Special
+hi def link typescriptExport                Keyword
 hi def link typescriptExportType            Special
 hi def link typescriptModule                Special
 hi def link typescriptTry                   Exception
@@ -2194,7 +2194,7 @@ hi def link typescriptAbstract              Special
 " hi def link typescriptClassHeritage         Function
 " hi def link typescriptInterfaceHeritage     Function
 hi def link typescriptClassStatic           StorageClass
-hi def link typescriptReadonlyModifier      Keyword
+hi def link typescriptReadonlyModifier      StorageClass
 hi def link typescriptInterfaceKeyword      Keyword
 hi def link typescriptInterfaceExtends      Keyword
 hi def link typescriptInterfaceName         Function

--- a/merged/typescriptreact.vim
+++ b/merged/typescriptreact.vim
@@ -2144,7 +2144,7 @@ hi def link typescriptCase                  Conditional
 hi def link typescriptDefault               typescriptCase
 hi def link typescriptBranch                Conditional
 hi def link typescriptIdentifier            Structure
-hi def link typescriptVariable              Identifier
+hi def link typescriptVariable              Keyword
 hi def link typescriptUsing                 Identifier
 hi def link typescriptDestructureVariable   PreProc
 hi def link typescriptEnumKeyword           Identifier
@@ -2152,8 +2152,8 @@ hi def link typescriptRepeat                Repeat
 hi def link typescriptForOperator           Repeat
 hi def link typescriptStatementKeyword      Statement
 hi def link typescriptMessage               Keyword
-hi def link typescriptOperator              Identifier
-hi def link typescriptKeywordOp             Identifier
+hi def link typescriptOperator              Operator
+hi def link typescriptKeywordOp             Operator
 hi def link typescriptCastKeyword           Special
 hi def link typescriptType                  Type
 hi def link typescriptNull                  Boolean
@@ -2164,14 +2164,14 @@ hi def link typescriptDestructureLabel      Function
 hi def link typescriptLabel                 Label
 hi def link typescriptTupleLable            Label
 hi def link typescriptStringProperty        String
-hi def link typescriptImport                Special
+hi def link typescriptImport                Keyword
 hi def link typescriptImportType            Special
 hi def link typescriptAmbientDeclaration    Special
 hi def link typescriptExport                Special
 hi def link typescriptExportType            Special
 hi def link typescriptModule                Special
-hi def link typescriptTry                   Special
-hi def link typescriptExceptions            Special
+hi def link typescriptTry                   Exception
+hi def link typescriptExceptions            Exception
 
 hi def link typescriptMember                Function
 hi def link typescriptMethodAccessor        Operator

--- a/syntax/common.vim
+++ b/syntax/common.vim
@@ -108,8 +108,8 @@ hi def link typescriptAmbientDeclaration    Special
 hi def link typescriptExport                Special
 hi def link typescriptExportType            Special
 hi def link typescriptModule                Special
-hi def link typescriptTry                   Special
-hi def link typescriptExceptions            Special
+hi def link typescriptTry                   Exception
+hi def link typescriptExceptions            Exception
 
 hi def link typescriptMember                Function
 hi def link typescriptMethodAccessor        Operator

--- a/syntax/common.vim
+++ b/syntax/common.vim
@@ -105,7 +105,7 @@ hi def link typescriptStringProperty        String
 hi def link typescriptImport                Keyword
 hi def link typescriptImportType            Special
 hi def link typescriptAmbientDeclaration    Special
-hi def link typescriptExport                Special
+hi def link typescriptExport                Keyword
 hi def link typescriptExportType            Special
 hi def link typescriptModule                Special
 hi def link typescriptTry                   Exception

--- a/syntax/common.vim
+++ b/syntax/common.vim
@@ -132,7 +132,7 @@ hi def link typescriptAbstract              Special
 " hi def link typescriptClassHeritage         Function
 " hi def link typescriptInterfaceHeritage     Function
 hi def link typescriptClassStatic           StorageClass
-hi def link typescriptReadonlyModifier      Keyword
+hi def link typescriptReadonlyModifier      StorageClass
 hi def link typescriptInterfaceKeyword      Keyword
 hi def link typescriptInterfaceExtends      Keyword
 hi def link typescriptInterfaceName         Function

--- a/syntax/common.vim
+++ b/syntax/common.vim
@@ -90,8 +90,8 @@ hi def link typescriptRepeat                Repeat
 hi def link typescriptForOperator           Repeat
 hi def link typescriptStatementKeyword      Statement
 hi def link typescriptMessage               Keyword
-hi def link typescriptOperator              Identifier
-hi def link typescriptKeywordOp             Identifier
+hi def link typescriptOperator              Operator
+hi def link typescriptKeywordOp             Operator
 hi def link typescriptCastKeyword           Special
 hi def link typescriptType                  Type
 hi def link typescriptNull                  Boolean

--- a/syntax/common.vim
+++ b/syntax/common.vim
@@ -102,7 +102,7 @@ hi def link typescriptDestructureLabel      Function
 hi def link typescriptLabel                 Label
 hi def link typescriptTupleLable            Label
 hi def link typescriptStringProperty        String
-hi def link typescriptImport                Special
+hi def link typescriptImport                Keyword
 hi def link typescriptImportType            Special
 hi def link typescriptAmbientDeclaration    Special
 hi def link typescriptExport                Special

--- a/syntax/common.vim
+++ b/syntax/common.vim
@@ -82,7 +82,7 @@ hi def link typescriptCase                  Conditional
 hi def link typescriptDefault               typescriptCase
 hi def link typescriptBranch                Conditional
 hi def link typescriptIdentifier            Structure
-hi def link typescriptVariable              Identifier
+hi def link typescriptVariable              Keyword
 hi def link typescriptUsing                 Identifier
 hi def link typescriptDestructureVariable   PreProc
 hi def link typescriptEnumKeyword           Identifier


### PR DESCRIPTION
This patch changes some highlight groups for certain keywords to align more closely with the vim docs:
https://vimdoc.sourceforge.net/htmldoc/syntax.html