### PR TITLE
Remove conceal feature from merged files

### DIFF
--- a/merge.js
+++ b/merge.js
@@ -10,7 +10,12 @@ function replace(_, indentation, filename) {
 }
 
 function importFile(source) {
-  return source.replace(/^([ \t]*)runtime (.+)?/gm, replace)
+  return source
+    .replace(/^([ \t]*)runtime (.+)?/gm, replace)
+    .replace(
+      /exec '([^']*)'\.\(exists\('g:typescript_conceal_[a-z]*'\) \? 'conceal cchar='\.g:typescript_conceal_[a-z]* : ''\)\.' ([^']*)'/gm,
+      (_, start, end) => start + end
+    )
 }
 
 var merged = importFile(entry)


### PR DESCRIPTION
The upstreamed files in vim remove this manually, so it is useful to have it handled automatically when generating the files.

I'm not sure if the merged files have use outside of upstreaming to vim? If so, then it might be better to have this controlled by a flag.

Previously discussed in #277.