### PR TITLE
Arbitrary module identifiers support

### DIFF
--- a/merged/typescript.vim
+++ b/merged/typescript.vim
@@ -256,10 +256,20 @@ syntax cluster typescriptSymbols               contains=typescriptBinaryOp,types
 "Import
 syntax keyword typescriptImport                from as
 syntax keyword typescriptImport                import
-  \ nextgroup=typescriptImportType,typescriptTypeBlock,typescriptDefaultImportName
+  \ nextgroup=typescriptImportType,typescriptImportBlock,typescriptDefaultImportName
   \ skipwhite
 syntax keyword typescriptImportType            type
   \ contained
+syntax match typescriptDefaultImportName /\v\h\k*( |,)/
+  \ contained
+  \ nextgroup=typescriptImportBlock
+  \ skipwhite skipempty
+syntax region  typescriptImportBlock
+  \ matchgroup=typescriptBraces
+  \ start=/{/ end=/}/
+  \ contained
+  \ contains=typescriptIdentifierName,typescriptImportType,typescriptString
+  \ fold
 syntax keyword typescriptExport                export
   \ nextgroup=typescriptExportType
   \ skipwhite
@@ -345,17 +355,6 @@ syntax cluster typescriptAmbients contains=
   \ typescriptModule
 
 syntax keyword typescriptIdentifier            arguments  nextgroup=@afterIdentifier
-syntax match typescriptDefaultImportName /\v\h\k*( |,)/
-  \ contained
-  \ nextgroup=typescriptTypeBlock
-  \ skipwhite skipempty
-
-syntax region  typescriptTypeBlock
-  \ matchgroup=typescriptBraces
-  \ start=/{/ end=/}/
-  \ contained
-  \ contains=typescriptIdentifierName,typescriptImportType
-  \ fold
 
 "Program Keywords
 exec 'syntax keyword typescriptNull null '.(exists('g:typescript_conceal_null') ? 'conceal cchar='.g:typescript_conceal_null : '').' nextgroup=@typescriptSymbols skipwhite skipempty'

--- a/merged/typescriptcommon.vim
+++ b/merged/typescriptcommon.vim
@@ -230,10 +230,20 @@ syntax cluster typescriptSymbols               contains=typescriptBinaryOp,types
 "Import
 syntax keyword typescriptImport                from as
 syntax keyword typescriptImport                import
-  \ nextgroup=typescriptImportType,typescriptTypeBlock,typescriptDefaultImportName
+  \ nextgroup=typescriptImportType,typescriptImportBlock,typescriptDefaultImportName
   \ skipwhite
 syntax keyword typescriptImportType            type
   \ contained
+syntax match typescriptDefaultImportName /\v\h\k*( |,)/
+  \ contained
+  \ nextgroup=typescriptImportBlock
+  \ skipwhite skipempty
+syntax region  typescriptImportBlock
+  \ matchgroup=typescriptBraces
+  \ start=/{/ end=/}/
+  \ contained
+  \ contains=typescriptIdentifierName,typescriptImportType,typescriptString
+  \ fold
 syntax keyword typescriptExport                export
   \ nextgroup=typescriptExportType
   \ skipwhite
@@ -319,17 +329,6 @@ syntax cluster typescriptAmbients contains=
   \ typescriptModule
 
 syntax keyword typescriptIdentifier            arguments  nextgroup=@afterIdentifier
-syntax match typescriptDefaultImportName /\v\h\k*( |,)/
-  \ contained
-  \ nextgroup=typescriptTypeBlock
-  \ skipwhite skipempty
-
-syntax region  typescriptTypeBlock
-  \ matchgroup=typescriptBraces
-  \ start=/{/ end=/}/
-  \ contained
-  \ contains=typescriptIdentifierName,typescriptImportType
-  \ fold
 
 "Program Keywords
 exec 'syntax keyword typescriptNull null '.(exists('g:typescript_conceal_null') ? 'conceal cchar='.g:typescript_conceal_null : '').' nextgroup=@typescriptSymbols skipwhite skipempty'
@@ -2027,7 +2026,7 @@ hi def link typescriptCase                  Conditional
 hi def link typescriptDefault               typescriptCase
 hi def link typescriptBranch                Conditional
 hi def link typescriptIdentifier            Structure
-hi def link typescriptVariable              Identifier
+hi def link typescriptVariable              Keyword
 hi def link typescriptUsing                 Identifier
 hi def link typescriptDestructureVariable   PreProc
 hi def link typescriptEnumKeyword           Identifier
@@ -2035,8 +2034,8 @@ hi def link typescriptRepeat                Repeat
 hi def link typescriptForOperator           Repeat
 hi def link typescriptStatementKeyword      Statement
 hi def link typescriptMessage               Keyword
-hi def link typescriptOperator              Identifier
-hi def link typescriptKeywordOp             Identifier
+hi def link typescriptOperator              Operator
+hi def link typescriptKeywordOp             Operator
 hi def link typescriptCastKeyword           Special
 hi def link typescriptType                  Type
 hi def link typescriptNull                  Boolean
@@ -2047,14 +2046,14 @@ hi def link typescriptDestructureLabel      Function
 hi def link typescriptLabel                 Label
 hi def link typescriptTupleLable            Label
 hi def link typescriptStringProperty        String
-hi def link typescriptImport                Special
+hi def link typescriptImport                Keyword
 hi def link typescriptImportType            Special
 hi def link typescriptAmbientDeclaration    Special
-hi def link typescriptExport                Special
+hi def link typescriptExport                Keyword
 hi def link typescriptExportType            Special
 hi def link typescriptModule                Special
-hi def link typescriptTry                   Special
-hi def link typescriptExceptions            Special
+hi def link typescriptTry                   Exception
+hi def link typescriptExceptions            Exception
 
 hi def link typescriptMember                Function
 hi def link typescriptMethodAccessor        Operator
@@ -2077,7 +2076,7 @@ hi def link typescriptAbstract              Special
 " hi def link typescriptClassHeritage         Function
 " hi def link typescriptInterfaceHeritage     Function
 hi def link typescriptClassStatic           StorageClass
-hi def link typescriptReadonlyModifier      Keyword
+hi def link typescriptReadonlyModifier      StorageClass
 hi def link typescriptInterfaceKeyword      Keyword
 hi def link typescriptInterfaceExtends      Keyword
 hi def link typescriptInterfaceName         Function

--- a/merged/typescriptreact.vim
+++ b/merged/typescriptreact.vim
@@ -352,10 +352,20 @@ syntax cluster typescriptSymbols               contains=typescriptBinaryOp,types
 "Import
 syntax keyword typescriptImport                from as
 syntax keyword typescriptImport                import
-  \ nextgroup=typescriptImportType,typescriptTypeBlock,typescriptDefaultImportName
+  \ nextgroup=typescriptImportType,typescriptImportBlock,typescriptDefaultImportName
   \ skipwhite
 syntax keyword typescriptImportType            type
   \ contained
+syntax match typescriptDefaultImportName /\v\h\k*( |,)/
+  \ contained
+  \ nextgroup=typescriptImportBlock
+  \ skipwhite skipempty
+syntax region  typescriptImportBlock
+  \ matchgroup=typescriptBraces
+  \ start=/{/ end=/}/
+  \ contained
+  \ contains=typescriptIdentifierName,typescriptImportType,typescriptString
+  \ fold
 syntax keyword typescriptExport                export
   \ nextgroup=typescriptExportType
   \ skipwhite
@@ -441,17 +451,6 @@ syntax cluster typescriptAmbients contains=
   \ typescriptModule
 
 syntax keyword typescriptIdentifier            arguments  nextgroup=@afterIdentifier
-syntax match typescriptDefaultImportName /\v\h\k*( |,)/
-  \ contained
-  \ nextgroup=typescriptTypeBlock
-  \ skipwhite skipempty
-
-syntax region  typescriptTypeBlock
-  \ matchgroup=typescriptBraces
-  \ start=/{/ end=/}/
-  \ contained
-  \ contains=typescriptIdentifierName,typescriptImportType
-  \ fold
 
 "Program Keywords
 exec 'syntax keyword typescriptNull null '.(exists('g:typescript_conceal_null') ? 'conceal cchar='.g:typescript_conceal_null : '').' nextgroup=@typescriptSymbols skipwhite skipempty'
@@ -2235,18 +2234,18 @@ hi def link typeScript                      NONE
 
 syntax cluster typescriptExpression add=tsxRegion,tsxFragment
 
-highlight def link tsxTag htmlTag
-highlight def link tsxTagName Function
-highlight def link tsxIntrinsicTagName htmlTagName
-highlight def link tsxString String
-highlight def link tsxNameSpace Function
-highlight def link tsxCommentInvalid Error
-highlight def link tsxBlockComment Comment
-highlight def link tsxLineComment Comment
-highlight def link tsxAttrib Type
-highlight def link tsxEscJs tsxEscapeJs
-highlight def link tsxCloseTag htmlTag
-highlight def link tsxCloseString Identifier
+hi def link tsxTag htmlTag
+hi def link tsxTagName Function
+hi def link tsxIntrinsicTagName htmlTagName
+hi def link tsxString String
+hi def link tsxNameSpace Function
+hi def link tsxCommentInvalid Error
+hi def link tsxBlockComment Comment
+hi def link tsxLineComment Comment
+hi def link tsxAttrib Type
+hi def link tsxEscJs tsxEscapeJs
+hi def link tsxCloseTag htmlTag
+hi def link tsxCloseString Identifier
 
 let b:current_syntax = "typescriptreact"
 if main_syntax == 'typescriptreact'

--- a/syntax/ts-common/keyword.vim
+++ b/syntax/ts-common/keyword.vim
@@ -1,10 +1,20 @@
 "Import
 syntax keyword typescriptImport                from as
 syntax keyword typescriptImport                import
-  \ nextgroup=typescriptImportType,typescriptTypeBlock,typescriptDefaultImportName
+  \ nextgroup=typescriptImportType,typescriptImportBlock,typescriptDefaultImportName
   \ skipwhite
 syntax keyword typescriptImportType            type
   \ contained
+syntax match typescriptDefaultImportName /\v\h\k*( |,)/
+  \ contained
+  \ nextgroup=typescriptImportBlock
+  \ skipwhite skipempty
+syntax region  typescriptImportBlock
+  \ matchgroup=typescriptBraces
+  \ start=/{/ end=/}/
+  \ contained
+  \ contains=typescriptIdentifierName,typescriptImportType,typescriptString
+  \ fold
 syntax keyword typescriptExport                export
   \ nextgroup=typescriptExportType
   \ skipwhite
@@ -90,17 +100,6 @@ syntax cluster typescriptAmbients contains=
   \ typescriptModule
 
 syntax keyword typescriptIdentifier            arguments  nextgroup=@afterIdentifier
-syntax match typescriptDefaultImportName /\v\h\k*( |,)/
-  \ contained
-  \ nextgroup=typescriptTypeBlock
-  \ skipwhite skipempty
-
-syntax region  typescriptTypeBlock
-  \ matchgroup=typescriptBraces
-  \ start=/{/ end=/}/
-  \ contained
-  \ contains=typescriptIdentifierName,typescriptImportType
-  \ fold
 
 "Program Keywords
 exec 'syntax keyword typescriptNull null '.(exists('g:typescript_conceal_null') ? 'conceal cchar='.g:typescript_conceal_null : '').' nextgroup=@typescriptSymbols skipwhite skipempty'

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -1161,3 +1161,43 @@ Execute:
   AssertEqual 'typescriptArrowFunc', SyntaxAt(13, 28)
   AssertEqual 'typescriptPromiseMethod', SyntaxAt(14, 7)
   AssertEqual 'typescriptFuncCallArg', SyntaxAt(14, 13)
+
+Given typescript (arbitrary module identifier in import block):
+  import { "hello" as hello } from "./hello";
+  import Default, { "hello" as hello } from "./hello";
+  import { foo, "hello" as hello } from "./hello";
+Execute:
+  " Validate `import`
+  AssertEqual 'typescriptImport', SyntaxAt(1, 1)
+  " Validate `"hello"`
+  AssertEqual 'typescriptString', SyntaxAt(1, 10)
+  " Validate `as`
+  AssertEqual 'typescriptCastKeyword', SyntaxAt(1, 18)
+  " Validate `hello`
+  AssertEqual 'typescriptTypeReference', SyntaxAt(1, 21)
+  " Validate `from`
+  AssertEqual 'typescriptImport', SyntaxAt(1, 29)
+  " Validate `import`
+  AssertEqual 'typescriptImport', SyntaxAt(2, 1)
+  " Validate `Default`
+  AssertEqual 'typescriptDefaultImportName', SyntaxAt(2, 8)
+  " Validate `"hello"`
+  AssertEqual 'typescriptString', SyntaxAt(2, 19)
+  " Validate `as`
+  AssertEqual 'typescriptCastKeyword', SyntaxAt(2, 27)
+  " Validate `hello`
+  AssertEqual 'typescriptTypeReference', SyntaxAt(2, 30)
+  " Validate `from`
+  AssertEqual 'typescriptImport', SyntaxAt(2, 38)
+  " Validate `import`
+  AssertEqual 'typescriptImport', SyntaxAt(3, 1)
+  " Validate `foo`
+  AssertEqual 'typescriptImportBlock', SyntaxAt(3, 10)
+  " Validate `"hello"`
+  AssertEqual 'typescriptString', SyntaxAt(3, 15)
+  " Validate `as`
+  AssertEqual 'typescriptCastKeyword', SyntaxAt(3, 23)
+  " Validate `hello`
+  AssertEqual 'typescriptTypeReference', SyntaxAt(3, 26)
+  " Validate `from`
+  AssertEqual 'typescriptImport', SyntaxAt(3, 34)


### PR DESCRIPTION
TypeScript 5.6 supported arbitrary module identifiers.

```ts
declare const some_imports: unknown;
export { some_imports as "some imports" };

import { "some imports" as foo } from "./module.js";
```

- https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/#support-for-arbitrary-module-identifiers4
- https://github.com/tc39/ecma262/pull/2154

Syntax highlighting for the `export` statement worked fine out-of-box but `import` statement didn't work (notice the string literal is not highlighted):

<img width="454" alt="image" src="https://github.com/user-attachments/assets/8cd93f0d-52f1-4f5d-8ea8-31174492a0c8">

This PR fixes the syntax highlighting with renaming `typescriptTypeBlock` to `typescriptImportBlock`. The screenshot after the fix is:

<img width="453" alt="image" src="https://github.com/user-attachments/assets/02b3c4da-03b4-4756-8a8d-e3bb3436ef3d">

I also updated the files in `merged/*.vim`.

