### PR TITLE
Support syntax highlighting for `import defer` statement

### DIFF
--- a/merged/typescript.vim
+++ b/merged/typescript.vim
@@ -256,7 +256,7 @@ syntax cluster typescriptSymbols               contains=typescriptBinaryOp,types
 "Import
 syntax keyword typescriptImport                from as
 syntax keyword typescriptImport                import
-  \ nextgroup=typescriptImportType,typescriptImportBlock,typescriptDefaultImportName
+  \ nextgroup=typescriptImportType,typescriptImportBlock,typescriptDefaultImportName,typescriptImportDefer
   \ skipwhite
 syntax keyword typescriptImportType            type
   \ contained
@@ -264,6 +264,8 @@ syntax match typescriptDefaultImportName /\v\h\k*( |,)/
   \ contained
   \ nextgroup=typescriptImportBlock
   \ skipwhite skipempty
+syntax match typescriptImportDefer             /\<defer\%(\s\+\*\)\@=/
+  \ contained
 syntax region  typescriptImportBlock
   \ matchgroup=typescriptBraces
   \ start=/{/ end=/}/
@@ -2073,11 +2075,12 @@ hi def link typescriptLabel                 Label
 hi def link typescriptTupleLable            Label
 hi def link typescriptStringProperty        String
 hi def link typescriptImport                Keyword
-hi def link typescriptImportType            Special
-hi def link typescriptAmbientDeclaration    Special
+hi def link typescriptImportType            Keyword
+hi def link typescriptImportDefer           Keyword
+hi def link typescriptAmbientDeclaration    Keyword
 hi def link typescriptExport                Keyword
-hi def link typescriptExportType            Special
-hi def link typescriptModule                Special
+hi def link typescriptExportType            Keyword 
+hi def link typescriptModule                Keyword
 hi def link typescriptTry                   Exception
 hi def link typescriptExceptions            Exception
 

--- a/merged/typescriptcommon.vim
+++ b/merged/typescriptcommon.vim
@@ -230,7 +230,7 @@ syntax cluster typescriptSymbols               contains=typescriptBinaryOp,types
 "Import
 syntax keyword typescriptImport                from as
 syntax keyword typescriptImport                import
-  \ nextgroup=typescriptImportType,typescriptImportBlock,typescriptDefaultImportName
+  \ nextgroup=typescriptImportType,typescriptImportBlock,typescriptDefaultImportName,typescriptImportDefer
   \ skipwhite
 syntax keyword typescriptImportType            type
   \ contained
@@ -238,6 +238,8 @@ syntax match typescriptDefaultImportName /\v\h\k*( |,)/
   \ contained
   \ nextgroup=typescriptImportBlock
   \ skipwhite skipempty
+syntax match typescriptImportDefer             /\<defer\%(\s\+\*\)\@=/
+  \ contained
 syntax region  typescriptImportBlock
   \ matchgroup=typescriptBraces
   \ start=/{/ end=/}/
@@ -2047,11 +2049,12 @@ hi def link typescriptLabel                 Label
 hi def link typescriptTupleLable            Label
 hi def link typescriptStringProperty        String
 hi def link typescriptImport                Keyword
-hi def link typescriptImportType            Special
-hi def link typescriptAmbientDeclaration    Special
+hi def link typescriptImportType            Keyword
+hi def link typescriptImportDefer           Keyword
+hi def link typescriptAmbientDeclaration    Keyword
 hi def link typescriptExport                Keyword
-hi def link typescriptExportType            Special
-hi def link typescriptModule                Special
+hi def link typescriptExportType            Keyword 
+hi def link typescriptModule                Keyword
 hi def link typescriptTry                   Exception
 hi def link typescriptExceptions            Exception
 

--- a/merged/typescriptreact.vim
+++ b/merged/typescriptreact.vim
@@ -352,7 +352,7 @@ syntax cluster typescriptSymbols               contains=typescriptBinaryOp,types
 "Import
 syntax keyword typescriptImport                from as
 syntax keyword typescriptImport                import
-  \ nextgroup=typescriptImportType,typescriptImportBlock,typescriptDefaultImportName
+  \ nextgroup=typescriptImportType,typescriptImportBlock,typescriptDefaultImportName,typescriptImportDefer
   \ skipwhite
 syntax keyword typescriptImportType            type
   \ contained
@@ -360,6 +360,8 @@ syntax match typescriptDefaultImportName /\v\h\k*( |,)/
   \ contained
   \ nextgroup=typescriptImportBlock
   \ skipwhite skipempty
+syntax match typescriptImportDefer             /\<defer\%(\s\+\*\)\@=/
+  \ contained
 syntax region  typescriptImportBlock
   \ matchgroup=typescriptBraces
   \ start=/{/ end=/}/
@@ -2169,11 +2171,12 @@ hi def link typescriptLabel                 Label
 hi def link typescriptTupleLable            Label
 hi def link typescriptStringProperty        String
 hi def link typescriptImport                Keyword
-hi def link typescriptImportType            Special
-hi def link typescriptAmbientDeclaration    Special
+hi def link typescriptImportType            Keyword
+hi def link typescriptImportDefer           Keyword
+hi def link typescriptAmbientDeclaration    Keyword
 hi def link typescriptExport                Keyword
-hi def link typescriptExportType            Special
-hi def link typescriptModule                Special
+hi def link typescriptExportType            Keyword 
+hi def link typescriptModule                Keyword
 hi def link typescriptTry                   Exception
 hi def link typescriptExceptions            Exception
 

--- a/syntax/common.vim
+++ b/syntax/common.vim
@@ -104,6 +104,7 @@ hi def link typescriptTupleLable            Label
 hi def link typescriptStringProperty        String
 hi def link typescriptImport                Keyword
 hi def link typescriptImportType            Keyword
+hi def link typescriptImportDefer           Keyword
 hi def link typescriptAmbientDeclaration    Keyword
 hi def link typescriptExport                Keyword
 hi def link typescriptExportType            Keyword 

--- a/syntax/ts-common/keyword.vim
+++ b/syntax/ts-common/keyword.vim
@@ -1,7 +1,7 @@
 "Import
 syntax keyword typescriptImport                from as
 syntax keyword typescriptImport                import
-  \ nextgroup=typescriptImportType,typescriptImportBlock,typescriptDefaultImportName
+  \ nextgroup=typescriptImportType,typescriptImportBlock,typescriptDefaultImportName,typescriptImportDefer
   \ skipwhite
 syntax keyword typescriptImportType            type
   \ contained
@@ -9,6 +9,8 @@ syntax match typescriptDefaultImportName /\v\h\k*( |,)/
   \ contained
   \ nextgroup=typescriptImportBlock
   \ skipwhite skipempty
+syntax match typescriptImportDefer             /\<defer\%(\s\+\*\)\@=/
+  \ contained
 syntax region  typescriptImportBlock
   \ matchgroup=typescriptBraces
   \ start=/{/ end=/}/

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -1201,3 +1201,18 @@ Execute:
   AssertEqual 'typescriptTypeReference', SyntaxAt(3, 26)
   " Validate `from`
   AssertEqual 'typescriptImport', SyntaxAt(3, 34)
+
+Given typescript (import defer statement):
+  import defer * as feature from "./some-feature.js";
+  import defer { doSomething } from "some-module";
+  import defer defaultExport from "some-module";
+  const defer = "test";
+Execute:
+  " `defer` is highlighted as keyword
+  AssertEqual 'typescriptImportDefer', SyntaxAt(1, 8)
+  AssertEqual 'typescriptImportDefer', SyntaxAt(1, 12)
+  " `defer` is not highlighed because these are illegal
+  AssertNotEqual 'typescriptImportDefer', SyntaxAt(2, 8)
+  AssertNotEqual 'typescriptImportDefer', SyntaxAt(3, 8)
+  " `defer` is not highlighted because it's not a part of import statement
+  AssertEqual 'typescriptVariableDeclaration', SyntaxAt(4, 7)


### PR DESCRIPTION
`import defer` is a new statement introduced in TypeScript 5.9 where `defer` is a new contextual keyword.

https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/#support-for-import-defer

This PR adds the support to ytas.vim. `import defer` is only allowed with `*` so `defer` is not highlighted in other cases. This PR also updates merged files so that I would be able to update Vim official runtime files as well.

Screenshot:

<img width="537" height="182" alt="image" src="https://github.com/user-attachments/assets/27cd7cd2-4da0-4e84-ab51-620fc0626d37" />