### PR TITLE
Remove trailing `%` from makeprg

### DIFF
--- a/compiler/typescript.vim
+++ b/compiler/typescript.vim
@@ -16,6 +16,6 @@ if !exists('g:typescript_compiler_options')
   endif
 endif
 
-let &l:makeprg = g:typescript_compiler_binary . ' ' . g:typescript_compiler_options . ' $* %'
+let &l:makeprg = g:typescript_compiler_binary . ' ' . g:typescript_compiler_options . ' $*'
 
 CompilerSet errorformat+=%+A\ %#%f\ %#(%l\\\,%c):\ %m,%C%m


### PR DESCRIPTION
Removing this allows more flexibility: the user can run `:make %` for the same behaviour as before, or `:make --project .` to build/check the whole project.

Closes #298